### PR TITLE
fix: update Android SDK to 35 to fix CI hang

### DIFF
--- a/demo-app/App_Resources/Android/app.gradle
+++ b/demo-app/App_Resources/Android/app.gradle
@@ -4,13 +4,13 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 34
-  buildToolsVersion "34"
+  compileSdkVersion 35
+  buildToolsVersion "35.0.0"
   // ndkVersion ""
 
   defaultConfig {
     minSdkVersion 23
-    targetSdkVersion 34
+    targetSdkVersion 35
 
     // Version Information
     versionCode 1


### PR DESCRIPTION
compileSdkVersion 34 / buildToolsVersion "34" caused the CI to hang for 6h because AGP 8.7.0 (NativeScript 8.9.1 default) tried to auto-download the missing build-tools;34.0.0 via sdkmanager, which prompted for license acceptance and waited forever.

The ubuntu-latest runner image no longer pre-installs SDK 34 components. Aligning with the NativeScript 8.9.1 defaults (SDK 35) fixes the hang.