### PR TITLE
Fix crash on Android hardware back button for routes without dynamic segments

### DIFF
--- a/ember-native/src/services/history.ts
+++ b/ember-native/src/services/history.ts
@@ -33,9 +33,15 @@ export default class HistoryService extends Service {
     if (h?.from) {
       const from = h.from;
       this.stack = [...this.stack];
+      // `from.params` is always an object, even `{}` for routes with no
+      // dynamic segments (e.g. `index`). Passing that empty object through
+      // as a context/model makes Ember's router throw "More context
+      // objects were passed than there are dynamic segments for the
+      // route", so only forward it when it actually holds a segment value.
+      const hasDynamicSegments = from.params && Object.keys(from.params).length > 0;
       const transition = this.nativeRouter.transitionTo(
         from.name,
-        from.params,
+        hasDynamicSegments ? from.params : undefined,
         {
           queryParams: from.queryParams,
         },


### PR DESCRIPTION
## Summary
- Fixes the pre-existing bug flagged in #393: pressing the Android hardware back button on a route with no dynamic segments (e.g. `index`) crashed with `Error: More context objects were passed than there are dynamic segments for the route: index`.
- Root cause: `HistoryService#back()` always forwarded `transition.from.params` as the model/context argument to `nativeRouter.transitionTo`. `RouteInfo#params` is always an object — `{}` for routes with no dynamic segments — and since `{}` is truthy, it was always passed through as a context object, even when the target route accepts zero context objects. Ember's router then throws.
- Fix: only forward `from.params` when it actually contains a segment value (`Object.keys(from.params).length > 0`); otherwise pass `undefined`, matching how `<LinkTo>` already calls `transitionTo` for routes with no model.

## Test plan
- [x] `pnpm lint:types` (glint) passes on `ember-native`
- [x] `eslint src/services/history.ts` passes
- [ ] On-device verification (Android back button from `index` route) — no emulator available in this environment; verified via code/type review instead. Please confirm on-device before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)