### PR TITLE
Fix HistoryService#back() using stale params for routes with dynamic segments

### DIFF
--- a/ember-native/src/services/history.ts
+++ b/ember-native/src/services/history.ts
@@ -6,10 +6,29 @@ import type Router from '@ember/routing/router';
 import type { Transition } from 'router_js';
 import { registerDestructor } from '@ember/destroyable';
 
+/**
+ * A snapshot of the route `back()` should return to, captured at push time (see `setup()`
+ * below) rather than read lazily off the live `Transition` at pop time. `Transition['from']` is
+ * a `RouteInfo` whose `params`/`queryParams` are only reliable while that route is still the
+ * *current* one - router_js reuses and updates a route's `RouteInfo` as the router moves on, so
+ * a stack entry sitting under other, later transitions can have its `from.params` read back
+ * empty (or otherwise stale) by the time an old entry is finally popped, even though the route
+ * had real params when it was current. Storing plain, copied values here instead means `back()`
+ * always transitions with the params the route actually had when it was left.
+ */
+type HistoryEntry = {
+  from: {
+    name: string;
+    params: Record<string, unknown>;
+    queryParams: Record<string, unknown>;
+  };
+  data: Transition['data'];
+};
+
 export default class HistoryService extends Service {
   @service router!: Router;
   @service('ember-native/native-router') nativeRouter!: NativeRouter;
-  @tracked stack: Transition[] = [];
+  @tracked stack: HistoryEntry[] = [];
 
   setup() {
     Application.android?.on('activityBackPressed', this.activityBackPressed);
@@ -18,7 +37,14 @@ export default class HistoryService extends Service {
     );
     this.router.on('routeDidChange', (transition) => {
       if (transition.from && !transition.data['isBack']) {
-        this.stack.push(transition);
+        this.stack.push({
+          from: {
+            name: transition.from.name,
+            params: { ...transition.from.params },
+            queryParams: { ...transition.from.queryParams },
+          },
+          data: transition.data,
+        });
         this.stack = [...this.stack];
       }
     });


### PR DESCRIPTION
## Summary

- `HistoryService.stack` stored the live `router_js` `Transition` pushed on each `routeDidChange`, then read `transition.from.params`/`queryParams` lazily when `back()` later popped that entry off the stack.
- `transition.from` is a `RouteInfo` that router_js reuses/updates for a route as the router moves on to other routes, so its `params`/`queryParams` are only reliable while that route is still current. A stack entry sitting under later transitions can have its `from.params` read back empty by the time it's finally popped, even though the route had real params when it was left.
- `back()`'s own `hasDynamicSegments` check (added in ba748f9, to fix a different crash) then wrongly treats such a route as needing no model, so it transitions without one — silently no-oping back onto the same route instead of the intended dynamic-segment destination, while the stack entry is discarded regardless of whether the transition actually landed. Reported symptom: back sometimes does nothing, and a second (hardware) press jumps back further than one screen, because the entry lost to the no-op is skipped.
- Fix: snapshot `from.name`/`params`/`queryParams` as plain copied values in `setup()`'s `routeDidChange` handler, at push time, instead of storing the live `Transition` and reading its `RouteInfo` lazily at pop time.

Traced and confirmed via a consumer app that was hitting this live (repro'd with `routeWillChange`/`routeDidChange` logging of dynamic-segment params, not just route names) and had worked around it at the app level pending this fix.

## Test plan

- [x] `pnpm --filter ember-native lint` (eslint, template-lint, glint types) passes
- [ ] Exercise `back()` on a device/emulator for a route with dynamic segments (e.g. push A -> B -> C, then pop back through B to A) and confirm params are correct and no press silently no-ops - I couldn't run the NativeScript/karma device test suite in this environment, so this needs manual or CI verification.