### PR TITLE
Fix HistoryService#back() still reading stale RouteInfo params

### DIFF
--- a/ember-native/src/services/history.ts
+++ b/ember-native/src/services/history.ts
@@ -7,21 +7,25 @@ import type { Transition } from 'router_js';
 import { registerDestructor } from '@ember/destroyable';
 
 /**
- * A snapshot of the route `back()` should return to, captured at push time (see `setup()`
- * below) rather than read lazily off the live `Transition` at pop time. `Transition['from']` is
- * a `RouteInfo` whose `params`/`queryParams` are only reliable while that route is still the
- * *current* one - router_js reuses and updates a route's `RouteInfo` as the router moves on, so
- * a stack entry sitting under other, later transitions can have its `from.params` read back
- * empty (or otherwise stale) by the time an old entry is finally popped, even though the route
- * had real params when it was current. Storing plain, copied values here instead means `back()`
- * always transitions with the params the route actually had when it was left.
+ * A snapshot of the URL `back()` should return to, captured from `router.currentURL` in
+ * `routeWillChange` - while the route being left is still the router's actual current route -
+ * rather than read off `Transition['from']`'s `RouteInfo` at any later point.
+ *
+ * `RouteInfo` is an object router_js owns and keeps mutating/reusing for a route across
+ * transitions, most visibly for a same-route dynamic-segment change (e.g. `commit-detail`'s
+ * `navigateToParent`, which transitions from `commit-detail` back to `commit-detail` under a
+ * different sha) - so its `params`/`queryParams` are not a reliable point-in-time snapshot no
+ * matter how early after the transition they're read. `b69ef22` moved this capture from `back()`
+ * reading it lazily at pop time to `setup()` copying it eagerly at push time (in
+ * `routeDidChange`), which closes the widest version of the gap but not all of it: the same
+ * route's `RouteInfo` can already read back empty by the time `routeDidChange` fires for it a
+ * second time. `currentURL` is a plain string the router computes once per settled transition -
+ * once read here it can't be mutated out from under us the way a `RouteInfo`'s properties can,
+ * and it round-trips the full destination (route, dynamic segments, and query params alike)
+ * through `router.transitionTo` without needing to reconstruct any of them separately.
  */
 type HistoryEntry = {
-  from: {
-    name: string;
-    params: Record<string, unknown>;
-    queryParams: Record<string, unknown>;
-  };
+  url: string;
   data: Transition['data'];
 };
 
@@ -35,14 +39,16 @@ export default class HistoryService extends Service {
     registerDestructor(this, () =>
       Application.android?.off('activityBackPressed', this.activityBackPressed),
     );
+    this.router.on('routeWillChange', (transition) => {
+      // The route being left is still current at this point - `didTransition` (which flips
+      // `currentURL` to the destination) hasn't run yet. See the `HistoryEntry` doc comment
+      // above for why this is read here instead of off `transition.from` later on.
+      transition.data['fromURL'] = this.router.currentURL;
+    });
     this.router.on('routeDidChange', (transition) => {
       if (transition.from && !transition.data['isBack']) {
         this.stack.push({
-          from: {
-            name: transition.from.name,
-            params: { ...transition.from.params },
-            queryParams: { ...transition.from.queryParams },
-          },
+          url: transition.data['fromURL'] as string,
           data: transition.data,
         });
         this.stack = [...this.stack];
@@ -56,23 +62,9 @@ export default class HistoryService extends Service {
 
   back = () => {
     const h = this.stack.pop();
-    if (h?.from) {
-      const from = h.from;
+    if (h?.url) {
       this.stack = [...this.stack];
-      // `from.params` is always an object, even `{}` for routes with no
-      // dynamic segments (e.g. `index`). Passing that empty object through
-      // as a context/model makes Ember's router throw "More context
-      // objects were passed than there are dynamic segments for the
-      // route", so only forward it when it actually holds a segment value.
-      const hasDynamicSegments = from.params && Object.keys(from.params).length > 0;
-      const transition = this.nativeRouter.transitionTo(
-        from.name,
-        hasDynamicSegments ? from.params : undefined,
-        {
-          queryParams: from.queryParams,
-        },
-        h.data['transition'] as any,
-      );
+      const transition = this.nativeRouter.transitionToURL(h.url, h.data['transition'] as any);
       transition.data['isBack'] = true;
       return true;
     }

--- a/ember-native/src/services/native-router.ts
+++ b/ember-native/src/services/native-router.ts
@@ -24,4 +24,20 @@ export default class NativeRouter extends Service {
     t.data['transition'] = backTransition || transition;
     return t;
   }
+
+  /**
+   * Same as {@link transitionTo}, but for transitioning to a full URL (route + dynamic segments
+   * + query params already resolved into one string) rather than reconstructing them from a
+   * route name and separate models/query-params - see `HistoryService`'s doc comment for why
+   * `back()` uses this instead.
+   */
+  transitionToURL(
+    url: string,
+    transition?: { transition: NavigationTransition; animated: boolean },
+  ) {
+    setNextTransition(transition?.transition, transition?.animated);
+    const t = this.router.transitionTo(url);
+    t.data['transition'] = transition;
+    return t;
+  }
 }


### PR DESCRIPTION
## Summary

- `b69ef22` (already on this branch) fixed `HistoryService#back()` reading `transition.from.params`/`queryParams` lazily off the live `Transition` at *pop* time, by copying them into a plain object eagerly in `routeDidChange`, at *push* time.
- That closes the widest version of the staleness window but not all of it: `RouteInfo` is an object router_js keeps mutating/reusing for a route across transitions - most visibly for a same-route dynamic-segment change (e.g. `commit-detail`'s `navigateToParent`, transitioning from `commit-detail` back to `commit-detail` under a different sha). Its `params` can already read back empty by the time `routeDidChange` fires for that route a *second* time, even though it's captured at push time. `back()`'s `hasDynamicSegments` check then treats the route as needing no model and the transition silently no-ops, while the stack entry is discarded regardless.
- Reproduced live on-device: back sometimes does nothing, and a second press jumps back further than one screen (the lost entry).
- Fixed by dropping `RouteInfo` from this path entirely: `router.currentURL` is a plain string computed once per settled transition, captured in a `routeWillChange` listener while the route being left is still current (`didTransition`, which flips `currentURL` to the destination, hasn't run yet). Once read, it can't be mutated out from under `HistoryService` the way a `RouteInfo`'s properties can. `back()` now transitions by that URL via a new `NativeRouter#transitionToURL`, which also collapses route + dynamic segments + query params into one atomic value instead of reconstructing them separately.

Found and worked around at the app level in a consumer (`github-plus/git-online-helper-app`) after `b69ef22`'s fix turned out to be incomplete; that app's retry-based workaround can be removed once this lands.

## Test plan

- [x] `pnpm run lint:types` (glint) passes
- [x] `pnpm run lint:js` (eslint) passes
- [ ] Manual verification on-device/emulator with a consumer app exercising same-route dynamic-segment back navigation (e.g. drilling through parent commits and pressing back repeatedly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)