### PR TITLE
Give window a real addEventListener and mark document ready at boot

### DIFF
--- a/ember-native/src/dom/nodes/DocumentNode.ts
+++ b/ember-native/src/dom/nodes/DocumentNode.ts
@@ -43,6 +43,11 @@ export default class DocumentNode extends ViewNode {
   documentElement = {
     dataset: {},
   };
+  // There's no async page-loading phase in a native app - the "document" is available
+  // immediately, unlike a browser's parse-then-load sequence. QUnit checks this before
+  // registering a `window` `load` listener to autostart: without it fixed at `'complete'`,
+  // it waits for a `load` event that a native app never fires, and tests never start.
+  readyState = 'complete';
 
   static getInstance() {
     if (!document) {

--- a/ember-native/src/setup.ts
+++ b/ember-native/src/setup.ts
@@ -261,6 +261,18 @@ export function setup() {
     origin: '',
     protocol: 'none',
   } as any;
+  // `window` is `globalThis` itself here, not a real DOM `EventTarget` - but callers assume it
+  // behaves like one (e.g. this file's own `document.body` getter below, and test frameworks like
+  // QUnit, which unconditionally call `window.addEventListener('unhandledrejection', ...)` during
+  // its own boot and crash otherwise). Mix in the same listener bookkeeping as the `EventTarget`
+  // polyfill above rather than making `globalThis` extend it (it can't - it's a fixed object, not
+  // a class instance).
+  if (typeof g.addEventListener !== 'function') {
+    const windowEventTarget = new (globalThis.EventTarget as any)();
+    g.addEventListener = windowEventTarget.addEventListener.bind(windowEventTarget);
+    g.removeEventListener = windowEventTarget.removeEventListener.bind(windowEventTarget);
+    g.dispatchEvent = windowEventTarget.dispatchEvent.bind(windowEventTarget);
+  }
   const document = new DocumentNode() as unknown as Document;
   (document as unknown as any).location = globalThis.window.location;
 


### PR DESCRIPTION
## Summary

- `setup.ts` aliases `window` to `globalThis`, but never gave it `addEventListener`/`removeEventListener`/`dispatchEvent` - despite this same file's own `document.body` getter already assuming `globalThis.addEventListener` exists.
- qunit 2.25's own boot sequence calls `window.addEventListener('unhandledrejection', ...)` unconditionally, and conditionally registers a `'load'` listener to autostart tests when `document.readyState !== 'complete'` - neither of which a native app ever fires. With no `addEventListener` at all, **any qunit-based test suite for an ember-native app crashes before a single test runs**: `TypeError: elem.addEventListener is not a function`.
- Fixed by mixing the existing `EventTarget` polyfill (already used for `AbortSignal`) onto `window`/`globalThis`, since `globalThis` can't literally extend a class (it's a fixed object, not an instantiable one).
- Also set `DocumentNode#readyState = 'complete'`: there's no async parse-then-load phase in a native app, so qunit should call `QUnit.autostart()` directly instead of waiting on a `'load'` event that will never fire (which would otherwise silently mean tests never start, even once `addEventListener` stops crashing).

Found while getting `git-online-helper-app`'s karma/qunit suite running on an emulator for the first time - it had apparently never successfully run to completion.

## Test plan

- [x] `pnpm run lint:types` (glint) passes
- [x] `pnpm run lint:js` (eslint) passes
- [x] Verified against a real consumer app (`git-online-helper-app`) by patching the equivalent compiled JS into its `node_modules` and confirming its karma/qunit suite now boots and runs on an Android emulator (previously crashed at startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)