### PR TITLE
Fix npm publish failure for new packages (access public)

### DIFF
--- a/karma-launcher/package.json
+++ b/karma-launcher/package.json
@@ -13,6 +13,9 @@
   },
   "license": "Apache-2.0",
   "author": "Patrick Pircher",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "index.js",
   "files": [
     "index.js",

--- a/unit-test-runner/package.json
+++ b/unit-test-runner/package.json
@@ -13,6 +13,9 @@
   },
   "license": "Apache-2.0",
   "author": "Patrick Pircher",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "app/main.js",
   "types": "app/main.d.ts",
   "files": [


### PR DESCRIPTION
## Summary
- PR #406's "Publish Stable" run published `ember-native@5.0.0` successfully, but failed on the two brand-new packages (`karma-ember-native-launcher@1.0.0`, `ember-native-unit-test-runner@1.0.0`) with `npm error EUSAGE: Can't generate provenance for new or private package, you must set access to public.`
- Root cause: CI publishes with `NPM_CONFIG_PROVENANCE=true`, and npm refuses to guess public/restricted access for a package name it's never seen before.
- Fix: add `publishConfig.access: "public"` to both new packages' `package.json`, matching what npm requires for a first-time publish with provenance.

## Test plan
- [ ] CI (`build & lint`, `test app`) passes
- [ ] After merge, manually re-run the `Publish Stable` workflow (`workflow_dispatch`) since it only auto-triggers on `.release-plan.json` changes
- [ ] Confirm both packages appear on npm: `npm view karma-ember-native-launcher`, `npm view ember-native-unit-test-runner`