### PR TITLE
Fix release-build boot crash for classes registered via @JavaProxy

### DIFF
--- a/ember-native/package.json
+++ b/ember-native/package.json
@@ -37,7 +37,7 @@
     "start:types": "glint --declaration --watch",
     "debug:types": "glint --debug-intermediate-representation",
     "prepack": "pnpm build",
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'"
+    "test": "node --test utils/*.test.js"
   },
   "peerDependencies": {
     "@glimmer/component": "*",
@@ -76,7 +76,8 @@
     "rollup-plugin-astroturf": "https://codeload.github.com/patricklx/rollup-plugin-astroturf/tar.gz/5354c7a",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-root-import": "^1.0.0",
-    "rollup-plugin-styles": "^4.0.0"
+    "rollup-plugin-styles": "^4.0.0",
+    "typescript": "^5.9.2"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.28.5",
@@ -140,7 +141,6 @@
     "router_js": "^8.0.6",
     "sass": "^1.94.2",
     "sass-embedded": "^1.90.0",
-    "typescript": "^5.9.2",
     "typescript-eslint": "^8.38.0",
     "typescript-plugin-css-modules": "^5.2.0",
     "yui": "^3.18.1"

--- a/ember-native/rollup.config.mjs
+++ b/ember-native/rollup.config.mjs
@@ -117,6 +117,11 @@ export default {
         { src: '../LICENSE.md', dest: '.' },
         { src: './utils/**/*', dest: './dist/utils' },
       ],
+      // *.test.js files live alongside the utils they test (see
+      // javaproxy-sbg-hint.test.js) and run via `pnpm test` straight out of
+      // `utils/`, before this copy step - they don't need to ship in the
+      // published package.
+      ignore: ['**/*.test.js'],
     }),
   ],
 };

--- a/ember-native/utils/javaproxy-sbg-hint.js
+++ b/ember-native/utils/javaproxy-sbg-hint.js
@@ -1,0 +1,189 @@
+/**
+ * NativeScript's Static Binding Generator (SBG) scans built app JS for the
+ * literal `SomeNativeClass.extend("java.Class.Name", { methodA(){}, ... })`
+ * call pattern to generate a matching native (Java) stub class at build
+ * time - a pure AST/text scan requiring both arguments to be literals
+ * (confirmed by reading a real app's
+ * `platforms/android/build-tools/jsparser/js_parser.js` directly: it
+ * explicitly requires `isStringLiteral`/`isObjectExpression` on the two
+ * arguments, and bails out otherwise).
+ *
+ * `global.JavaProxy` (from `@nativescript/android`'s `ts_helpers.js`,
+ * exposed as a TypeScript class decorator - see that file's own
+ * `global.JavaProxy = JavaProxy` line) is a different, indirect convention:
+ * `@JavaProxy(name)` compiles to `X = __decorate([JavaProxy(name)], X)`,
+ * and the *actual* `.extend()` call happens inside `ts_helpers.js`'s own
+ * `JavaProxy` factory (`target.extend(className, target.prototype)`) - not
+ * as literal text at the `__decorate(...)` call site, and with `.prototype`
+ * (a property access, not an object literal) as the second argument even
+ * where it does appear. SBG's parser can't trace either indirection, so it
+ * silently generates no native stub for any class registered this way.
+ * `@nativescript/core`'s own `application.android.js` uses this exact
+ * pattern for `NativeScriptLifecycleCallbacksImpl`/
+ * `NativeScriptComponentCallbacksImpl` - `Application.run()` then throws
+ * `LookedUpClassNotFound` synchronously at boot in every release build that
+ * doesn't already have some other route to a matching stub.
+ *
+ * `@nativescript/vite` already has a similar, narrower fix
+ * (`helpers/nativeclass-transform.js`) for its own `@NativeClass()`
+ * decorator convention, confirmed by its own comments ("SBG expects the
+ * __decorate call to be INSIDE the IIFE... the IIFE pattern with
+ * __decorate inside is correct") - but that transform's own guard
+ * (`/\bNativeClass\b/`) never matches `JavaProxy`, so it doesn't cover this
+ * case. This is the equivalent fix for `@JavaProxy`, generalized to any
+ * `X = __decorate([JavaProxy("name")], X)` site (not hardcoded to the two
+ * known `@nativescript/core` classes), so it also covers similar code in any
+ * other dependency, and stays correct automatically if `@nativescript/core`
+ * ever adds/renames a method on either class (the method list is read from
+ * the actual source, not hand-copied).
+ *
+ * Fix: for each such site, walk the enclosing IIFE
+ * (`(function (_super) { ...; X = __decorate(...); return X; }(SuperExpr))`)
+ * to find `X.prototype.<method> = function ... {}` assignments and the
+ * `SuperExpr` the IIFE was invoked with, then append a dead-code hint
+ * statement - `if (globalThis.<guard>) { (SuperExpr).extend("name", {
+ * method(){}, ... }); }` - using the *original source text* for `SuperExpr`
+ * so it resolves to the exact same qualified native-class reference SBG
+ * needs. The condition is a dynamic property read Rollup's tree-shaking
+ * can't prove is always false, so the hint text survives bundling for SBG
+ * to find, but the branch never actually executes (avoiding any
+ * duplicate-registration risk against the real `@JavaProxy`-driven
+ * registration for the same class names).
+ */
+
+const ts = require('typescript');
+
+const GUARD = '__sbgJavaProxyHintNeverTrue__';
+
+function findPrototypeMethods(fnBody, targetName) {
+  const methods = [];
+  for (const stmt of fnBody.statements) {
+    if (
+      !ts.isExpressionStatement(stmt) ||
+      !ts.isBinaryExpression(stmt.expression) ||
+      stmt.expression.operatorToken.kind !== ts.SyntaxKind.EqualsToken
+    ) {
+      continue;
+    }
+    const left = stmt.expression.left;
+    if (
+      ts.isPropertyAccessExpression(left) &&
+      ts.isPropertyAccessExpression(left.expression) &&
+      ts.isIdentifier(left.expression.expression) &&
+      left.expression.expression.text === targetName &&
+      left.expression.name.text === 'prototype'
+    ) {
+      methods.push(left.name.text);
+    }
+  }
+  return methods;
+}
+
+function findEnclosingIifeSuperExpr(node, sourceFile) {
+  let fn = node.parent;
+  while (fn && !ts.isFunctionExpression(fn)) fn = fn.parent;
+  if (!fn) return null;
+
+  let call = fn.parent;
+  // `(function (_super) {...}(SuperExpr))` - the parenthesization wraps the
+  // whole call, not just the function, so `fn.parent` is the CallExpression
+  // directly; tolerate an extra ParenthesizedExpression layer too, in case a
+  // future @nativescript/core release formats this differently.
+  if (call && ts.isParenthesizedExpression(call)) call = call.parent;
+  if (!call || !ts.isCallExpression(call) || call.expression !== fn || call.arguments.length < 1) {
+    return null;
+  }
+
+  const superExprNode = call.arguments[0];
+  return {
+    fnBody: fn.body,
+    superExprText: sourceFile.text.slice(superExprNode.getStart(sourceFile), superExprNode.getEnd()),
+  };
+}
+
+function collectJavaProxyHints(sourceFile) {
+  const hints = [];
+
+  function visit(node) {
+    if (
+      ts.isExpressionStatement(node) &&
+      ts.isBinaryExpression(node.expression) &&
+      node.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken
+    ) {
+      const { left, right } = node.expression;
+      if (
+        ts.isIdentifier(left) &&
+        ts.isCallExpression(right) &&
+        ts.isIdentifier(right.expression) &&
+        right.expression.text === '__decorate' &&
+        right.arguments.length >= 2 &&
+        ts.isArrayLiteralExpression(right.arguments[0]) &&
+        right.arguments[0].elements.length === 1 &&
+        ts.isIdentifier(right.arguments[1]) &&
+        right.arguments[1].text === left.text
+      ) {
+        const decorator = right.arguments[0].elements[0];
+        if (
+          ts.isCallExpression(decorator) &&
+          ts.isIdentifier(decorator.expression) &&
+          decorator.expression.text === 'JavaProxy' &&
+          decorator.arguments.length === 1 &&
+          ts.isStringLiteral(decorator.arguments[0])
+        ) {
+          const iife = findEnclosingIifeSuperExpr(node, sourceFile);
+          if (iife) {
+            const methods = findPrototypeMethods(iife.fnBody, left.text);
+            if (methods.length > 0) {
+              hints.push({
+                className: decorator.arguments[0].text,
+                superExprText: iife.superExprText,
+                methods,
+              });
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return hints;
+}
+
+/**
+ * @param {string} code
+ * @param {string} id
+ * @returns {string|null} the transformed code, or null if this file has no
+ *   `@JavaProxy`-decorated classes to hint.
+ */
+function javaProxySbgHint(code, id) {
+  // Fast pre-filter before parsing - same pattern as @nativescript/vite's
+  // own nativeclass-transform.js.
+  if (!/__decorate[a-zA-Z$]*\s*\(/.test(code) || !/\bJavaProxy\b/.test(code)) return null;
+
+  const sourceFile = ts.createSourceFile(id, code, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const hints = collectJavaProxyHints(sourceFile);
+  if (hints.length === 0) return null;
+
+  const hintStatements = hints
+    .map(({ superExprText, className, methods }) => {
+      const methodStubs = methods.map((m) => `${JSON.stringify(m)}: function () {}`).join(', ');
+      return `(${superExprText}).extend(${JSON.stringify(className)}, { ${methodStubs} });`;
+    })
+    .join('\n  ');
+
+  return `${code}\nif (globalThis.${GUARD}) {\n  ${hintStatements}\n}\n`;
+}
+
+module.exports = function javaProxySbgHintPlugin() {
+  return {
+    name: 'ember-native-javaproxy-sbg-hint',
+    transform(code, id) {
+      const transformed = javaProxySbgHint(code, id);
+      return transformed === null ? null : { code: transformed, map: null };
+    },
+  };
+};
+
+module.exports.javaProxySbgHint = javaProxySbgHint;

--- a/ember-native/utils/javaproxy-sbg-hint.test.js
+++ b/ember-native/utils/javaproxy-sbg-hint.test.js
@@ -1,0 +1,93 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { javaProxySbgHint } = require('./javaproxy-sbg-hint.js');
+
+// Trimmed down, but otherwise verbatim shape of @nativescript/core's real
+// `application.android.js` (both `NativeScriptLifecycleCallbacksImpl` and
+// `NativeScriptComponentCallbacksImpl`, the two classes whose missing SBG
+// binding caused every release build to throw `LookedUpClassNotFound` at
+// boot - see javaproxy-sbg-hint.js's own docstring for the full incident).
+// This is a *production* regression test: it fixture-matches the exact
+// compiled-JS shape that broke in production, not an idealized input.
+const REAL_APPLICATION_ANDROID_JS = `
+let NativeScriptLifecycleCallbacks_;
+function initNativeScriptLifecycleCallbacks() {
+    if (NativeScriptLifecycleCallbacks_) {
+        return NativeScriptLifecycleCallbacks_;
+    }
+    var NativeScriptLifecycleCallbacksImpl = (function (_super) {
+        __extends(NativeScriptLifecycleCallbacksImpl, _super);
+        function NativeScriptLifecycleCallbacksImpl() {
+            return (_super !== null && _super.apply(this, arguments)) || this;
+        }
+        NativeScriptLifecycleCallbacksImpl.prototype.onActivityCreated = function (activity, savedInstanceState) {};
+        NativeScriptLifecycleCallbacksImpl.prototype.onActivityDestroyed = function (activity) {};
+        NativeScriptLifecycleCallbacksImpl = __decorate([
+            JavaProxy("org.nativescript.NativeScriptLifecycleCallbacks")
+        ], NativeScriptLifecycleCallbacksImpl);
+        return NativeScriptLifecycleCallbacksImpl;
+    }(android.app.Application.ActivityLifecycleCallbacks));
+    NativeScriptLifecycleCallbacks_ = NativeScriptLifecycleCallbacksImpl;
+    return NativeScriptLifecycleCallbacks_;
+}
+let NativeScriptComponentCallbacks_;
+function initNativeScriptComponentCallbacks() {
+    if (NativeScriptComponentCallbacks_) {
+        return NativeScriptComponentCallbacks_;
+    }
+    var NativeScriptComponentCallbacksImpl = (function (_super) {
+        __extends(NativeScriptComponentCallbacksImpl, _super);
+        function NativeScriptComponentCallbacksImpl() {
+            return (_super !== null && _super.apply(this, arguments)) || this;
+        }
+        NativeScriptComponentCallbacksImpl.prototype.onLowMemory = function () {};
+        NativeScriptComponentCallbacksImpl.prototype.onTrimMemory = function (level) {};
+        NativeScriptComponentCallbacksImpl.prototype.onConfigurationChanged = function (newConfiguration) {};
+        NativeScriptComponentCallbacksImpl = __decorate([
+            JavaProxy("org.nativescript.NativeScriptComponentCallbacks")
+        ], NativeScriptComponentCallbacksImpl);
+        return NativeScriptComponentCallbacksImpl;
+    }(android.content.ComponentCallbacks2));
+    NativeScriptComponentCallbacks_ = NativeScriptComponentCallbacksImpl;
+    return NativeScriptComponentCallbacks_;
+}
+`;
+
+test('emits an SBG hint for every @JavaProxy-decorated class, with the real method list and superclass expression', () => {
+  const output = javaProxySbgHint(REAL_APPLICATION_ANDROID_JS, 'application.android.js');
+  assert.ok(output, 'expected a transform to be produced for real @nativescript/core source');
+
+  assert.match(output, /if \(globalThis\.__sbgJavaProxyHintNeverTrue__\) \{/);
+
+  assert.match(
+    output,
+    /\(android\.app\.Application\.ActivityLifecycleCallbacks\)\.extend\("org\.nativescript\.NativeScriptLifecycleCallbacks", \{ "onActivityCreated": function \(\) \{\}, "onActivityDestroyed": function \(\) \{\} \}\);/,
+  );
+  assert.match(
+    output,
+    /\(android\.content\.ComponentCallbacks2\)\.extend\("org\.nativescript\.NativeScriptComponentCallbacks", \{ "onLowMemory": function \(\) \{\}, "onTrimMemory": function \(\) \{\}, "onConfigurationChanged": function \(\) \{\} \}\);/,
+  );
+
+  // The hint must be dead code - SBG only needs to *see* the literal
+  // `.extend(...)` text, it never actually has to run. A regression here
+  // (guard flipped/removed) would double-register these classes against
+  // @nativescript/core's own real, decorator-driven registration.
+  assert.equal(globalThis.__sbgJavaProxyHintNeverTrue__, undefined);
+  new Function(output)();
+});
+
+test('is a no-op for files with no @JavaProxy usage', () => {
+  assert.equal(javaProxySbgHint('const x = 1;', 'unrelated.js'), null);
+});
+
+test('is a no-op for __decorate calls that reference a different decorator', () => {
+  const code = `
+    var Foo = (function (_super) {
+      __extends(Foo, _super);
+      Foo.prototype.bar = function () {};
+      Foo = __decorate([SomeOtherDecorator("x")], Foo);
+      return Foo;
+    }(Base));
+  `;
+  assert.equal(javaProxySbgHint(code, 'unrelated.js'), null);
+});

--- a/ember-native/utils/vite.config.js
+++ b/ember-native/utils/vite.config.js
@@ -35,6 +35,7 @@ module.exports = function configureEmberNativeVite(options = {}) {
   const { babel } = require('@rollup/plugin-babel');
   const replace = require('@rollup/plugin-replace');
   const dependencySourcePatches = require('./vite-dependency-patches.js');
+  const javaProxySbgHintPlugin = require('./javaproxy-sbg-hint.js');
 
   return {
     resolve: {
@@ -104,6 +105,16 @@ module.exports = function configureEmberNativeVite(options = {}) {
       }),
       earlyGlobalsBanner(),
       dependencySourcePatches(),
+      // Every ember-native Android app depends on @nativescript/core, whose
+      // own application.android.js registers its lifecycle/component
+      // callbacks via `@JavaProxy(...)` - a pattern the Static Binding
+      // Generator can't see through on its own (see javaproxy-sbg-hint.js's
+      // own docstring for the full mechanism). Without this, every release
+      // build throws `LookedUpClassNotFound` at boot. On by default here
+      // (rather than left for each app to opt into) since it's required for
+      // any of them to boot at all in release mode, and is a no-op for any
+      // file that doesn't contain a `@JavaProxy`-decorated class.
+      javaProxySbgHintPlugin(),
     ],
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-ember:
         specifier: ^12.3.1
-        version: 12.7.5(5ff893536b5be6763174ded7d398637d)
+        version: 12.7.5(84740c278c3325a0cf2a0506dc099481)
       eslint-plugin-n:
         specifier: ^17.23.1
         version: 17.24.0(0d62767105e9a39fc494591cb6137847)
@@ -735,6 +735,9 @@ importers:
       rollup-plugin-styles:
         specifier: ^4.0.0
         version: 4.0.0(rollup@4.60.1)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.28.5
@@ -919,9 +922,6 @@ importers:
       sass-embedded:
         specifier: ^1.90.0
         version: 1.99.0
-      typescript:
-        specifier: ^5.9.2
-        version: 5.9.3
       typescript-eslint:
         specifier: ^8.38.0
         version: 8.58.1(0d62767105e9a39fc494591cb6137847)
@@ -23827,6 +23827,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.61.0(0d62767105e9a39fc494591cb6137847)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3(supports-color@9.4.0)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@typescript-eslint/parser@8.61.0(717face55a559967bf1b77f9b43bd1f1)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
@@ -28149,6 +28162,23 @@ snapshots:
       - eslint
       - typescript
 
+  ember-eslint-parser@0.5.13(84740c278c3325a0cf2a0506dc099481):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/eslint-parser': 7.28.6(35c79763e2f529503c5fce6757258eb9)
+      '@glimmer/syntax': 0.95.0
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      content-tag: 2.0.3
+      eslint-scope: 7.2.2
+      html-tags: 3.3.1
+      mathml-tag-names: 2.1.3
+      svg-tags: 1.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.61.0(0d62767105e9a39fc494591cb6137847)
+    transitivePeerDependencies:
+      - eslint
+      - typescript
+
   ember-eslint-parser@0.5.13(b21a5c2d82ffcddaa5ddcd8b5e86f59d):
     dependencies:
       '@babel/core': 7.29.0
@@ -28334,6 +28364,7 @@ snapshots:
       rollup-plugin-postcss: 4.0.2(postcss@8.5.16)
       rollup-plugin-root-import: 1.0.0
       rollup-plugin-styles: 4.0.0(rollup@4.60.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@embroider/core'
       - '@glint/template'
@@ -29230,6 +29261,25 @@ snapshots:
       snake-case: 3.0.4
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(0d62767105e9a39fc494591cb6137847)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - typescript
+
+  eslint-plugin-ember@12.7.5(84740c278c3325a0cf2a0506dc099481):
+    dependencies:
+      '@ember-data/rfc395-data': 0.0.4
+      css-tree: 3.2.1
+      ember-eslint-parser: 0.5.13(84740c278c3325a0cf2a0506dc099481)
+      ember-rfc176-data: 0.3.18
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.6.1))
+      estraverse: 5.3.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      requireindex: 1.2.0
+      snake-case: 3.0.4
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.61.0(0d62767105e9a39fc494591cb6137847)
     transitivePeerDependencies:
       - '@babel/core'
       - typescript


### PR DESCRIPTION
## Summary

- `@nativescript/core`'s `application.android.js` registers its lifecycle/component callbacks (`NativeScriptLifecycleCallbacksImpl`, `NativeScriptComponentCallbacksImpl`) via the `@JavaProxy` decorator, which compiles to `X = __decorate([JavaProxy(name)], X)`. The actual `.extend()` call happens indirectly, inside `@nativescript/android`'s `ts_helpers.js` factory - not as literal text at the decorator call site. NativeScript's Static Binding Generator only recognizes the literal `SomeClass.extend("java.Class.Name", {...})` shape, so it silently generates no native stub for classes registered this way. `Application.run()` then throws `LookedUpClassNotFound` synchronously at boot - in every release build, on any ember-native Android app.
- `@nativescript/vite` already works around the equivalent problem for its own `@NativeClass()` decorator (`helpers/nativeclass-transform.js`), but that transform's guard (`/\bNativeClass\b/`) never matches `JavaProxy`.
- Adds `ember-native/utils/javaproxy-sbg-hint.js`, a Vite/Rollup `transform` plugin wired into `configureEmberNativeVite()` so every app gets it automatically with **no app-side config changes**. It parses each transformed file with the TypeScript compiler API, finds every `X = __decorate([JavaProxy("name")], X)` site, and derives the real method list and superclass expression from the surrounding IIFE to emit a dead-code SBG hint statement - the literal-argument shape SBG already knows how to bind, without the hint ever actually executing (avoiding double registration against the real decorator-driven registration).
- Moves `typescript` from `devDependencies` to a real `dependency`, since this transform needs it at runtime in every consuming app's build, not just for developing this package.

## Verification

- New `ember-native/utils/javaproxy-sbg-hint.test.js` (`node --test`) asserts correct extraction against a fixture built from `@nativescript/core`'s actual compiled `application.android.js` shape (both affected classes), plus negative cases for files with no `@JavaProxy` usage and for unrelated decorators.
- Full `pnpm build` (rollup + tsc + glint) succeeds; confirmed the plugin ships to `dist/utils/` while the new test file is excluded from the published package.
- The identical transform logic was already verified end-to-end as a per-app workaround: a real signed release AAB build, correct `sbg-bindings.txt` entries for both classes, and a full on-device boot to a rendered screen (previously crashed with `LookedUpClassNotFound` before the fix).

## Test plan

- [x] `pnpm test` passes in `ember-native/`
- [x] `pnpm build` succeeds
- [ ] CI on this PR