### PR TITLE
Fix Glimmer bridging bookkeeping in ListView/RadListView

### DIFF
--- a/ember-native/src/components/ListView.gts
+++ b/ember-native/src/components/ListView.gts
@@ -53,6 +53,7 @@ type Ref<T> = {
 
 export default class ListView<T> extends Component<ListViewInterface<T>> {
   @tracked elementRefs: Ref<T>[] = [];
+  private elementRefsByNativeView = new Map<StackLayout, Ref<T>>();
   private listViewElement?: NativeElementNode<NativeListView>;
 
   get items(): Ref<T>[] {
@@ -82,6 +83,7 @@ export default class ListView<T> extends Component<ListViewInterface<T>> {
         ((listView.nativeView as any)._realizedItems).delete(
           elementRef.element.nativeView,
         );
+        this.elementRefsByNativeView.delete(elementRef.element.nativeView);
       }
     }
     this.elementRefs = this.elementRefs.filter(
@@ -136,11 +138,13 @@ export default class ListView<T> extends Component<ListViewInterface<T>> {
         listViewComponent.cleanup(listView);
         const sl = DocumentNode.createElement('stack-layout');
         listView.appendChild(sl);
-        listViewComponent.elementRefs.push({
+        const ref: Ref<T> = {
           element: sl,
           item: null,
           index,
-        });
+        };
+        listViewComponent.elementRefs.push(ref);
+        listViewComponent.elementRefsByNativeView.set(sl.nativeView, ref);
         listViewComponent.elementRefs = [...listViewComponent.elementRefs];
         return sl.nativeView;
       }
@@ -150,8 +154,8 @@ export default class ListView<T> extends Component<ListViewInterface<T>> {
         stackLayout: StackLayout,
         index: number,
       ) => {
-        const ref = listViewComponent.elementRefs.find(
-          (e) => e.element.nativeView === stackLayout,
+        const ref = listViewComponent.elementRefsByNativeView.get(
+          stackLayout,
         )!;
         if (ref.index === index) {
           return;

--- a/ember-native/src/components/RadListView.gts
+++ b/ember-native/src/components/RadListView.gts
@@ -9,22 +9,48 @@ import NativeElementNode from '../dom/native/NativeElementNode.ts';
 import DocumentNode from '../dom/nodes/DocumentNode.ts';
 import type { StackLayout } from '@nativescript/core';
 
-class TrackedMap extends Map<any, any> {
-  @tracked counter = 0;
-  set(key: any, value: any): this {
-    this.counter += 1;
-    super.set(key, value);
+class Ref<T> {
+  @tracked value: T;
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+
+// A Map whose per-key values are individually tracked, so updating one
+// entry only invalidates consumers of that entry rather than everything
+// that reads the map (e.g. an `entries()`-derived list).
+class TrackedMap<K, V> {
+  @tracked private structure = 0;
+  private map = new Map<K, Ref<V>>();
+
+  set(key: K, value: V): this {
+    const existing = this.map.get(key);
+    if (existing) {
+      existing.value = value;
+    } else {
+      this.map.set(key, new Ref(value));
+      this.structure += 1;
+    }
     return this;
   }
 
-  get(key: any): any {
-    if (this.counter === 0) return null;
-    return super.get(key);
+  get(key: K): V | undefined {
+    return this.map.get(key)?.value;
   }
 
-  entries(): any {
-    if (this.counter === 0) return super.entries();
-    return super.entries();
+  delete(key: K): boolean {
+    const deleted = this.map.delete(key);
+    if (deleted) {
+      this.structure += 1;
+    }
+    return deleted;
+  }
+
+  keys(): K[] {
+    // Read `structure` so callers that only need the set of keys (not the
+    // values) don't get invalidated by unrelated per-key value updates.
+    void this.structure;
+    return [...this.map.keys()];
   }
 }
 
@@ -44,13 +70,14 @@ interface RadListViewInterface<T> {
 export default class RadListView<T = any> extends Component<
   RadListViewInterface<T>
 > {
-  elementRefs: TrackedMap = new TrackedMap();
+  elementRefs: TrackedMap<NativeElementNode<StackLayout>, T> =
+    new TrackedMap();
   @tracked private listView: NativeElementNode<NativeRadListView> | undefined;
   private declare headerElement: NativeElementNode<StackLayout>;
   private declare footerElement: NativeElementNode<StackLayout>;
 
   cleanup(listView: NativeElementNode<NativeRadListView>) {
-    for (const [element] of [...this.elementRefs.entries()]) {
+    for (const element of this.elementRefs.keys()) {
       const n = element.nativeView.nativeViewProtected;
       if (!n || !n.getWindowToken()) {
         this.elementRefs.delete(element);
@@ -70,10 +97,16 @@ export default class RadListView<T = any> extends Component<
   }
 
   get items() {
-    return [...this.elementRefs.entries()].map(([element, item]) => {
+    const elementRefs = this.elementRefs;
+    // Only the set of keys is read here, so updating a single row's
+    // bindingContext (via elementRefs.set) doesn't invalidate this getter
+    // for the other rows; `item` is read per-row in the template instead.
+    return elementRefs.keys().map((element) => {
       return {
-        item,
         element,
+        get item() {
+          return elementRefs.get(element);
+        },
       };
     });
   }


### PR DESCRIPTION
## Summary
- `ListView._prepareItem` did a linear `.find()` over `elementRefs` on every native recycle callback during scroll; replaced with an O(1) `Map<nativeView, Ref>` lookup maintained alongside `elementRefs` (updated on push in `_getDefaultItemContent`, on delete in `cleanup()`).
- `RadListView`'s `TrackedMap` bumped one shared `@tracked counter` on every `set()`, so any single row rebind invalidated the whole `items` getter/each-block instead of just that row. Replaced with per-entry `@tracked` values (a small `Ref` wrapper) so row rebinds only invalidate that row; the `items` getter now only depends on the map's key structure (add/delete), not per-row values. Also removed the `counter===0` → `null` landmine (`get()` now returns `undefined` like a normal `Map`) and the dead duplicate-branch `entries()` method.

Native `ListView`/`RadListView` already handle virtualization/row recycling themselves, so these are correctness/architecture-quality fixes to the Glimmer bridging layer, not measured perf wins (no perf harness exists in this repo). Follow-up to #166.

## Test plan
- [x] `pnpm exec tsc --noEmit` — pre-existing baseline failure only (`.gts` files aren't resolvable by plain `tsc`; unrelated to this change)
- [x] `pnpm exec glint` (the real type checker for `.gts`/templates) — clean, no errors, same as baseline
- [x] `pnpm exec eslint src/components/ListView.gts src/components/RadListView.gts` — clean
- [ ] No runnable unit test suite covers these components (NativeScript on-device karma runner only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)