### PR TITLE
Fix ActionBar <action-item> removal losing ActionItems bookkeeping

### DIFF
--- a/ember-native/package.json
+++ b/ember-native/package.json
@@ -37,7 +37,7 @@
     "start:types": "glint --declaration --watch",
     "debug:types": "glint --debug-intermediate-representation",
     "prepack": "pnpm build",
-    "test": "node --test utils/*.test.js"
+    "test": "node --test utils/*.test.js src/dom/native/*.test.ts"
   },
   "peerDependencies": {
     "@glimmer/component": "*",

--- a/ember-native/rollup.config.mjs
+++ b/ember-native/rollup.config.mjs
@@ -41,11 +41,10 @@ export default {
     // up your addon's public API. Also make sure your package.json#exports
     // is aligned to the config here.
     // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
-    addon.publicEntrypoints([
-      '**/*.{js,ts}',
-      'index.js',
-      'template-registry.js',
-    ]),
+    addon.publicEntrypoints(
+      ['**/*.{js,ts}', 'index.js', 'template-registry.js'],
+      { exclude: ['**/*.test.ts'] },
+    ),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but

--- a/ember-native/src/dom/native/NativeElementNode.ts
+++ b/ember-native/src/dom/native/NativeElementNode.ts
@@ -1,5 +1,6 @@
 import { KeyframeAnimation } from '@nativescript/core/ui/animation/keyframe-animation';
 import { LayoutBase } from '@nativescript/core/ui/layouts/layout-base';
+import { ActionBar, ActionItem } from '@nativescript/core/ui/action-bar';
 import {
   ContentView,
   type EventData,
@@ -15,6 +16,7 @@ import { type ViewBase } from '@nativescript/core/ui/core/view-base';
 import { TextBase } from '@nativescript/core/ui/text-base';
 import ElementNode from '../nodes/ElementNode.ts';
 import ViewNode, { type EventListener } from '../nodes/ViewNode.ts';
+import { removeActionBarChild } from './action-item-removal.ts';
 
 function camelize(kebab: string): string {
   return kebab.replace(/-+(\w)/g, (_m, l) => l.toUpperCase());
@@ -392,6 +394,18 @@ export default class NativeElementNode<
         (parentView as any).content = null;
       }
       if (childNode.nodeType === 8) {
+        parentView._removeView(childView);
+      }
+    } else if (parentView instanceof ActionBar && childView instanceof ActionItem) {
+      if (childNode.parentNode !== parentNode) {
+        return;
+      }
+      // actionItems is nulled out by ActionBarBase.disposeNativeView(), which
+      // can run before this fires during teardown - fall back to the plain
+      // view-child removal in that case, same as before this branch existed.
+      if (parentView.actionItems) {
+        removeActionBarChild(parentView, childView);
+      } else {
         parentView._removeView(childView);
       }
     } else if (parentView instanceof View) {

--- a/ember-native/src/dom/native/action-item-removal.test.ts
+++ b/ember-native/src/dom/native/action-item-removal.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="node" />
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { removeActionBarChild, type ActionBarLike } from './action-item-removal.ts';
+
+// Mirrors the real shape of @nativescript/core's ActionItems.removeItem(),
+// which throws "Cannot find item to remove" for anything it never added -
+// see action-bar-common.js. This keeps the fake honest about what a real
+// misuse (removing an item ActionItems never registered) would do.
+function createFakeActionBar(initialItems: string[]): {
+  actionBar: ActionBarLike<string>;
+  items: string[];
+  removedViaActionItems: string[];
+  removedViaGenericView: string[];
+} {
+  const items = initialItems.slice();
+  const removedViaActionItems: string[] = [];
+  const removedViaGenericView: string[] = [];
+
+  const actionBar: ActionBarLike<string> = {
+    actionItems: {
+      getItems: () => items.slice(),
+      removeItem: (item) => {
+        const index = items.indexOf(item);
+        if (index < 0) {
+          throw new Error('Cannot find item to remove');
+        }
+        items.splice(index, 1);
+        removedViaActionItems.push(item);
+      },
+    },
+    _removeView: (item) => {
+      removedViaGenericView.push(item);
+    },
+  };
+
+  return { actionBar, items, removedViaActionItems, removedViaGenericView };
+}
+
+test('removes a registered action item through ActionItems.removeItem, not the generic _removeView', () => {
+  const { actionBar, items, removedViaActionItems, removedViaGenericView } =
+    createFakeActionBar(['settings']);
+
+  removeActionBarChild(actionBar, 'settings');
+
+  assert.deepEqual(items, [], 'item should be gone from ActionItems bookkeeping');
+  assert.deepEqual(removedViaActionItems, ['settings']);
+  assert.deepEqual(
+    removedViaGenericView,
+    [],
+    'must not fall back to the generic path once ActionItems handled it',
+  );
+});
+
+test('falls back to the generic _removeView for an item ActionItems never registered', () => {
+  const { actionBar, removedViaActionItems, removedViaGenericView } = createFakeActionBar([]);
+
+  removeActionBarChild(actionBar, 'nav-button');
+
+  assert.deepEqual(removedViaActionItems, []);
+  assert.deepEqual(removedViaGenericView, ['nav-button']);
+});
+
+test('a remove -> re-add cycle leaves exactly one entry, not a duplicate', () => {
+  const { actionBar, items } = createFakeActionBar(['settings']);
+
+  removeActionBarChild(actionBar, 'settings');
+  assert.deepEqual(items, []);
+
+  // Simulate the re-add path (ActionBar._addChildFromBuilder ->
+  // actionItems.addItem()) landing the item back in the same bookkeeping
+  // array removeActionBarChild reads from.
+  items.push('settings');
+  assert.deepEqual(items, ['settings']);
+
+  removeActionBarChild(actionBar, 'settings');
+  assert.deepEqual(items, [], 'no leftover duplicate after a second removal');
+});

--- a/ember-native/src/dom/native/action-item-removal.ts
+++ b/ember-native/src/dom/native/action-item-removal.ts
@@ -1,0 +1,36 @@
+export interface ActionItemsLike<Item> {
+  getItems(): Item[];
+  removeItem(item: Item): void;
+}
+
+export interface ActionBarLike<Item> {
+  actionItems: ActionItemsLike<Item>;
+  _removeView(item: Item): void;
+}
+
+/**
+ * NativeScript's ActionBar keeps its own bookkeeping for action items
+ * (ActionItems._items) separate from the generic view-child tree - it's
+ * populated and depopulated only via ActionItems.addItem()/removeItem().
+ * Removing an <action-item> through the generic View._removeView() path
+ * (what every other kind of child uses) never touches that bookkeeping, so
+ * the item stays registered forever and the ActionBar - which rebuilds its
+ * whole menu from ActionItems.getVisibleItems() on every update() - keeps
+ * re-rendering it, duplicating on every subsequent re-add.
+ *
+ * Route the removal through actionItems.removeItem() whenever the item is
+ * actually registered there; fall back to _removeView() for anything an
+ * ActionBar hosts without going through ActionItems (e.g. a
+ * NavigationButton, which ActionBarBase's own navigationButton setter
+ * manages separately).
+ */
+export function removeActionBarChild<Item>(
+  actionBar: ActionBarLike<Item>,
+  childView: Item,
+): void {
+  if (actionBar.actionItems.getItems().includes(childView)) {
+    actionBar.actionItems.removeItem(childView);
+  } else {
+    actionBar._removeView(childView);
+  }
+}


### PR DESCRIPTION
## Summary
- `NativeElementNode.onRemovedChild` fell through to the generic `View` branch for a removed `<action-item>` and called `parentView._removeView(childView)` directly - NativeScript's `ActionBar` keeps a *separate* registry of its items (`ActionItems._items`), populated/depopulated only via `ActionItems.addItem()`/`removeItem()`, so the removed item stayed registered forever. Since Android's `ActionBar` rebuilds its whole menu from `getVisibleItems()` on every `update()`, the orphaned entry kept re-appearing, and re-adding the item later (e.g. re-mounting a conditionally-rendered `<action-item>`) stacked a duplicate on top.
- Added a special case in `onRemovedChild` that routes an `ActionItem` removal from an `ActionBar` parent through `actionItems.removeItem()` (falling back to the generic `_removeView` path for anything `ActionItems` never registered, e.g. after `disposeNativeView()` nulls `actionItems` out).
- Confirmed `onInsertedChild` already correctly dispatches an add through `_addChildFromBuilder` -> `actionItems.addItem()` on both Android and iOS - only removal was missing the bookkeeping.
- Added `src/dom/native/action-item-removal.ts`, a small pure/duck-typed helper holding the add/remove decision, with a `node --test` unit test (`action-item-removal.test.ts`) exercising it without a native runtime - mirrors `utils/javaproxy-sbg-hint.test.js`'s style from the earlier SBG-hint fix (#414).
- Excluded `**/*.test.ts` from the addon's `publicEntrypoints` rollup config, since colocating the new test file under `src/` would otherwise get it swept into a published public chunk with unresolved `node:test`/`node:assert` externals.

Found and reported by a consuming app (a NativeScript/Ember app that conditionally shows/hides an `<action-item>` via `{{#if}}`, which kept accumulating duplicate action-bar buttons on repeated toggles); worked around there by never unmounting the element and toggling `visibility` instead, but that workaround doesn't fix the underlying bug for other consumers or removal patterns.

## Test plan
- [x] `pnpm test` - `node --test utils/*.test.js src/dom/native/*.test.ts`, all 6 pass
- [x] `pnpm lint:js` - clean
- [x] `pnpm lint:types` (glint) - clean
- [x] `pnpm lint:hbs` - clean
- [x] `pnpm build` (`build:js` + `build:utils` + `build:types`) - clean, confirmed the fix and the `actionItems`/`ActionBar`/`ActionItem` references compile through into `dist/dom/native/NativeElementNode.js`, and confirmed a clean rebuild does **not** emit `dist/dom/native/action-item-removal.test.js` (the entrypoints exclude works)