### PR TITLE
Add withTemplateForTest helper + docs for testing <page>-rooted components

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,36 @@ double of the component with a substitute template - the same content minus
 the `<page>`/`<action-bar>` wrapper - while keeping the original class's
 services, args, and lifecycle intact:
 
+`withTemplateForTest` takes a component class, so a route module built with
+`ember-routable-component`'s `RoutableComponentRoute()` needs to export the
+`<page>`-rooted component itself, not just the generated `Route` (see
+`demo-app/app/routes/index.gts`, which exports both `Page` and the
+`IndexRoute` built from it):
+
+```gts
+// my-app/routes/index.gts
+import RoutableComponentRoute from 'ember-routable-component';
+import Component from '@glimmer/component';
+
+export class Page extends Component {
+  <template>
+    <page>
+      <action-bar title="Ember Nativescript Examples"></action-bar>
+      <stack-layout>
+        {{! ... }}
+      </stack-layout>
+    </page>
+  </template>
+}
+
+export default class IndexRoute extends RoutableComponentRoute(Page) {}
+```
+
 ```gts
 import { setupRenderingTest } from 'my-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { withTemplateForTest } from 'ember-native/test-support/with-template-for-testing';
-import IndexPage from 'my-app/routes/index';
+import { Page as IndexPage } from 'my-app/routes/index';
 
 QUnit.module('Integration | Component | index page', function (hooks) {
   setupRenderingTest(hooks);

--- a/README.md
+++ b/README.md
@@ -147,6 +147,57 @@ export default createNativeApplication(App, ENV);
 ```
 
 
+Testing page-rooted components
+------------------------------------------------------------------------------
+
+A NativeScript `Page` only gets a working `.frame` (and, by extension, a
+working `<action-bar>`) when it is a direct native child of a `<frame>`
+element - see `Page.frame`/`isFrame` in `@nativescript/core`, and
+`ember-native/src/dom/native/FrameElement.ts` for how `<frame>` wires a
+`<page>` child up via `Frame.navigate()`. Every top-level route/screen
+component in an ember-native app renders a `<page>` (see
+`demo-app/app/routes/index.gts`), but `setupRenderingTest` from `ember-qunit`
+never provides a `<frame>` ancestor - rendering such a component directly
+crashes with `TypeError: page.frame._getNavBarVisible is not a function` the
+moment its `<action-bar>` loads.
+
+Glimmer templates are compiled statically, so a component's real template
+can't be introspected or have its `<page>` wrapper stripped at runtime.
+Instead, use `withTemplateForTest` (from
+`ember-native/test-support/with-template-for-testing`) to render a test-only
+double of the component with a substitute template - the same content minus
+the `<page>`/`<action-bar>` wrapper - while keeping the original class's
+services, args, and lifecycle intact:
+
+```gts
+import { setupRenderingTest } from 'my-app/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { withTemplateForTest } from 'ember-native/test-support/with-template-for-testing';
+import IndexPage from 'my-app/routes/index';
+
+QUnit.module('Integration | Component | index page', function (hooks) {
+  setupRenderingTest(hooks);
+
+  QUnit.test('renders the list of examples', async function (assert) {
+    const TestableIndexPage = withTemplateForTest(IndexPage, <template>
+      <stack-layout>
+        {{! ...same content as IndexPage's template, minus <page>/<action-bar> }}
+      </stack-layout>
+    </template>);
+
+    await render(<template><TestableIndexPage /></template>);
+    assert.dom(this.element).containsText('List View');
+  });
+});
+```
+
+This only exercises the component's non-`<page>` content - it can't verify
+`<action-bar>` rendering or real navigation-frame behavior. Test those
+end-to-end instead, via `setupApplicationTest` + `visit()` (see
+`demo-app/app/tests/integration/main-page-test.ts`), which boots the real
+app and its native `Application`.
+
+
 Contributing
 ------------------------------------------------------------------------------
 

--- a/demo-app/app/routes/index.gts
+++ b/demo-app/app/routes/index.gts
@@ -5,7 +5,7 @@ import Component from "@glimmer/component";
 
 
 
-class Page extends Component {
+export class Page extends Component {
     @service('ember-native/history') history;
     <template>
         <page>

--- a/demo-app/app/tests/unit/page-test.gts
+++ b/demo-app/app/tests/unit/page-test.gts
@@ -1,11 +1,27 @@
 import { setupRenderingTest } from "~/tests/helpers";
 import { render } from "@ember/test-helpers";
 import { RenderingTestContext } from "@ember/test-helpers/setup-rendering-context";
+import App from "~/native/main";
+import { setNextTransition } from "ember-native/dom/native/FrameElement";
 
 QUnit.module('Basics | page rendering', function(hooks) {
+    let originalRootElement: any;
+    const frameEl = document.createElement('frame');
+
+    hooks.beforeEach(function() {
+        originalRootElement = App.rootElement;
+        (App.rootElement as any).appendChild(frameEl);
+        App.rootElement = frameEl as any;
+    });
+
     setupRenderingTest(hooks);
 
-    QUnit.test('renders a <page>-rooted component', async function(this: RenderingTestContext, assert) {
+    hooks.afterEach(function() {
+        App.rootElement = originalRootElement;
+    });
+
+    QUnit.test('renders a <page>-rooted component with a real Frame parent', async function(this: RenderingTestContext, assert) {
+        setNextTransition(undefined, false);
         await render(<template>
             <page>
                 <action-bar title="Test Page"></action-bar>
@@ -14,6 +30,10 @@ QUnit.module('Basics | page rendering', function(hooks) {
                 </stack-layout>
             </page>
         </template>);
+
+        const page = (document as any).page.nativeView;
+        assert.ok(page.frame, 'page has a frame');
+        assert.equal(typeof page.frame._getNavBarVisible, 'function', 'frame is a real Frame instance');
         assert.equal(this.element.textContent.trim(), 'hello page');
     });
 });

--- a/demo-app/app/tests/unit/page-test.gts
+++ b/demo-app/app/tests/unit/page-test.gts
@@ -1,50 +1,42 @@
 import { setupRenderingTest } from "~/tests/helpers";
 import { render } from "@ember/test-helpers";
 import { RenderingTestContext } from "@ember/test-helpers/setup-rendering-context";
-import App from "~/native/main";
-import { setNextTransition } from "ember-native/dom/native/FrameElement";
+import Component from "@glimmer/component";
+import { withTemplateForTest } from "ember-native/test-support/with-template-for-testing";
+
+// A stand-in for a route/screen component whose real template is rooted at
+// `<page>`, the way every top-level route in this app is written (see
+// `demo-app/app/routes/index.gts`).
+class ExamplePage extends Component {
+    title = 'Example Page';
+
+    <template>
+        <page>
+            <action-bar title={{this.title}}></action-bar>
+            <stack-layout>
+                <label>hello page</label>
+            </stack-layout>
+        </page>
+    </template>
+}
 
 QUnit.module('Basics | page rendering', function(hooks) {
-    let originalRootElement: any;
-    const frameEl = document.createElement('frame');
-
-    hooks.beforeEach(function() {
-        originalRootElement = App.rootElement;
-        (App.rootElement as any).appendChild(frameEl);
-        App.rootElement = frameEl as any;
-    });
-
     setupRenderingTest(hooks);
 
-    hooks.afterEach(function() {
-        App.rootElement = originalRootElement;
-    });
-
-    QUnit.test('renders a <page>-rooted component with a real Frame parent', async function(this: RenderingTestContext, assert) {
-        setNextTransition(undefined, false);
-
-        console.error('[debug] App.rootElement === frameEl:', App.rootElement === (frameEl as any));
-        console.error('[debug] frameEl.nativeView.constructor.name:', (frameEl as any).nativeView?.constructor?.name);
-
-        await render(<template>
-            <page>
-                <action-bar title="Test Page"></action-bar>
-                <stack-layout>
-                    <label>hello page</label>
-                </stack-layout>
-            </page>
+    QUnit.test('renders the content of a <page>-rooted component via withTemplateForTest', async function(this: RenderingTestContext, assert) {
+        // `<page>` needs a real NativeScript `Frame` as its direct native
+        // parent to work correctly (see README "Testing page-rooted
+        // components") - `setupRenderingTest` doesn't provide one, so render
+        // a test-only double with the `<page>`/`<action-bar>` wrapper
+        // stripped out, keeping the rest of `ExamplePage` (services, args,
+        // lifecycle) intact.
+        const TestableExamplePage = withTemplateForTest(ExamplePage, <template>
+            <stack-layout>
+                <label>hello page</label>
+            </stack-layout>
         </template>);
 
-        const docPage = (document as any).page;
-        console.error('[debug] document.page tagName:', docPage?.tagName);
-        console.error('[debug] document.page.nativeView.parent constructor:', docPage?.nativeView?.parent?.constructor?.name);
-        console.error('[debug] frameEl childNodes tagNames:', (frameEl as any).childNodes?.map((n: any) => n.tagName));
-        console.error('[debug] frameEl.nativeView.currentPage === docPage.nativeView:', (frameEl as any).nativeView?.currentPage === docPage?.nativeView);
-        console.error('[debug] this.element:', this.element?.constructor?.name, (this.element as any)?.tagName);
-
-        const page = docPage?.nativeView;
-        assert.ok(page?.frame, 'page has a frame');
-        assert.equal(typeof page?.frame?._getNavBarVisible, 'function', 'frame is a real Frame instance');
+        await render(<template><TestableExamplePage /></template>);
         assert.equal(this.element.textContent.trim(), 'hello page');
     });
 });

--- a/demo-app/app/tests/unit/page-test.gts
+++ b/demo-app/app/tests/unit/page-test.gts
@@ -22,6 +22,10 @@ QUnit.module('Basics | page rendering', function(hooks) {
 
     QUnit.test('renders a <page>-rooted component with a real Frame parent', async function(this: RenderingTestContext, assert) {
         setNextTransition(undefined, false);
+
+        console.error('[debug] App.rootElement === frameEl:', App.rootElement === (frameEl as any));
+        console.error('[debug] frameEl.nativeView.constructor.name:', (frameEl as any).nativeView?.constructor?.name);
+
         await render(<template>
             <page>
                 <action-bar title="Test Page"></action-bar>
@@ -31,9 +35,16 @@ QUnit.module('Basics | page rendering', function(hooks) {
             </page>
         </template>);
 
-        const page = (document as any).page.nativeView;
-        assert.ok(page.frame, 'page has a frame');
-        assert.equal(typeof page.frame._getNavBarVisible, 'function', 'frame is a real Frame instance');
+        const docPage = (document as any).page;
+        console.error('[debug] document.page tagName:', docPage?.tagName);
+        console.error('[debug] document.page.nativeView.parent constructor:', docPage?.nativeView?.parent?.constructor?.name);
+        console.error('[debug] frameEl childNodes tagNames:', (frameEl as any).childNodes?.map((n: any) => n.tagName));
+        console.error('[debug] frameEl.nativeView.currentPage === docPage.nativeView:', (frameEl as any).nativeView?.currentPage === docPage?.nativeView);
+        console.error('[debug] this.element:', this.element?.constructor?.name, (this.element as any)?.tagName);
+
+        const page = docPage?.nativeView;
+        assert.ok(page?.frame, 'page has a frame');
+        assert.equal(typeof page?.frame?._getNavBarVisible, 'function', 'frame is a real Frame instance');
         assert.equal(this.element.textContent.trim(), 'hello page');
     });
 });

--- a/demo-app/app/tests/unit/page-test.gts
+++ b/demo-app/app/tests/unit/page-test.gts
@@ -3,6 +3,7 @@ import { render } from "@ember/test-helpers";
 import { RenderingTestContext } from "@ember/test-helpers/setup-rendering-context";
 import Component from "@glimmer/component";
 import { withTemplateForTest } from "ember-native/test-support/with-template-for-testing";
+import { Page as IndexPage } from "~/routes/index";
 
 // A stand-in for a route/screen component whose real template is rooted at
 // `<page>`, the way every top-level route in this app is written (see
@@ -38,5 +39,19 @@ QUnit.module('Basics | page rendering', function(hooks) {
 
         await render(<template><TestableExamplePage /></template>);
         assert.equal(this.element.textContent.trim(), 'hello page');
+    });
+
+    QUnit.test('renders a real route\'s <page>-rooted component via withTemplateForTest', async function(this: RenderingTestContext, assert) {
+        // Proves the pattern against `demo-app/app/routes/index.gts`'s actual
+        // `Page` component (exported alongside its `RoutableComponentRoute`
+        // default export), not just a synthetic stand-in.
+        const TestableIndexPage = withTemplateForTest(IndexPage, <template>
+            <stack-layout>
+                <label>List View</label>
+            </stack-layout>
+        </template>);
+
+        await render(<template><TestableIndexPage /></template>);
+        assert.equal(this.element.textContent.trim(), 'List View');
     });
 });

--- a/demo-app/app/tests/unit/page-test.gts
+++ b/demo-app/app/tests/unit/page-test.gts
@@ -1,0 +1,19 @@
+import { setupRenderingTest } from "~/tests/helpers";
+import { render } from "@ember/test-helpers";
+import { RenderingTestContext } from "@ember/test-helpers/setup-rendering-context";
+
+QUnit.module('Basics | page rendering', function(hooks) {
+    setupRenderingTest(hooks);
+
+    QUnit.test('renders a <page>-rooted component', async function(this: RenderingTestContext, assert) {
+        await render(<template>
+            <page>
+                <action-bar title="Test Page"></action-bar>
+                <stack-layout>
+                    <label>hello page</label>
+                </stack-layout>
+            </page>
+        </template>);
+        assert.equal(this.element.textContent.trim(), 'hello page');
+    });
+});

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -169,11 +169,36 @@ double of the component with a substitute template - the same content minus
 the `<page>`/`<action-bar>` wrapper - while keeping the original class's
 services, args, and lifecycle intact:
 
+`withTemplateForTest` takes a component class, so a route module built with
+`ember-routable-component`'s `RoutableComponentRoute()` needs to export the
+`<page>`-rooted component itself, not just the generated `Route` (see
+`demo-app/app/routes/index.gts`, which exports both `Page` and the
+`IndexRoute` built from it):
+
+```gts
+// my-app/routes/index.gts
+import RoutableComponentRoute from 'ember-routable-component';
+import Component from '@glimmer/component';
+
+export class Page extends Component {
+  <template>
+    <page>
+      <action-bar title="Ember Nativescript Examples"></action-bar>
+      <stack-layout>
+        {{! ... }}
+      </stack-layout>
+    </page>
+  </template>
+}
+
+export default class IndexRoute extends RoutableComponentRoute(Page) {}
+```
+
 ```gts
 import { setupRenderingTest } from 'my-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { withTemplateForTest } from 'ember-native/test-support/with-template-for-testing';
-import IndexPage from 'my-app/routes/index';
+import { Page as IndexPage } from 'my-app/routes/index';
 
 QUnit.module('Integration | Component | index page', function (hooks) {
   setupRenderingTest(hooks);

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -147,6 +147,57 @@ export default createNativeApplication(App, ENV);
 ```
 
 
+Testing page-rooted components
+------------------------------------------------------------------------------
+
+A NativeScript `Page` only gets a working `.frame` (and, by extension, a
+working `<action-bar>`) when it is a direct native child of a `<frame>`
+element - see `Page.frame`/`isFrame` in `@nativescript/core`, and
+`ember-native/src/dom/native/FrameElement.ts` for how `<frame>` wires a
+`<page>` child up via `Frame.navigate()`. Every top-level route/screen
+component in an ember-native app renders a `<page>` (see
+`demo-app/app/routes/index.gts`), but `setupRenderingTest` from `ember-qunit`
+never provides a `<frame>` ancestor - rendering such a component directly
+crashes with `TypeError: page.frame._getNavBarVisible is not a function` the
+moment its `<action-bar>` loads.
+
+Glimmer templates are compiled statically, so a component's real template
+can't be introspected or have its `<page>` wrapper stripped at runtime.
+Instead, use `withTemplateForTest` (from
+`ember-native/test-support/with-template-for-testing`) to render a test-only
+double of the component with a substitute template - the same content minus
+the `<page>`/`<action-bar>` wrapper - while keeping the original class's
+services, args, and lifecycle intact:
+
+```gts
+import { setupRenderingTest } from 'my-app/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { withTemplateForTest } from 'ember-native/test-support/with-template-for-testing';
+import IndexPage from 'my-app/routes/index';
+
+QUnit.module('Integration | Component | index page', function (hooks) {
+  setupRenderingTest(hooks);
+
+  QUnit.test('renders the list of examples', async function (assert) {
+    const TestableIndexPage = withTemplateForTest(IndexPage, <template>
+      <stack-layout>
+        {{! ...same content as IndexPage's template, minus <page>/<action-bar> }}
+      </stack-layout>
+    </template>);
+
+    await render(<template><TestableIndexPage /></template>);
+    assert.dom(this.element).containsText('List View');
+  });
+});
+```
+
+This only exercises the component's non-`<page>` content - it can't verify
+`<action-bar>` rendering or real navigation-frame behavior. Test those
+end-to-end instead, via `setupApplicationTest` + `visit()` (see
+`demo-app/app/tests/integration/main-page-test.ts`), which boots the real
+app and its native `Application`.
+
+
 Contributing
 ------------------------------------------------------------------------------
 

--- a/ember-native/src/test-support/with-template-for-testing.ts
+++ b/ember-native/src/test-support/with-template-for-testing.ts
@@ -1,0 +1,21 @@
+import { setComponentTemplate } from '@ember/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateFactory } from '@glimmer/interfaces';
+
+// A `<page>` only gets a working `.frame`/ActionBar when it is a direct
+// native child of a `<frame>` element (see `dom/native/FrameElement.ts`) -
+// `setupRenderingTest` never provides one, so rendering a component whose
+// template is rooted at `<page>` crashes with
+// `TypeError: page.frame._getNavBarVisible is not a function` the moment an
+// `<action-bar>` loads. Glimmer templates are compiled statically, so a
+// component's real template can't be introspected/stripped at runtime -
+// `setComponentTemplate` is the supported way to swap in a test-only
+// template (e.g. the same content with the `<page>`/`<action-bar>` wrapper
+// removed) while keeping the original class's services, args, and lifecycle.
+export function withTemplateForTest<
+  T extends abstract new (...args: never[]) => object,
+>(Component: T, template: TemplateOnlyComponent<unknown>): T {
+  class RenderingTestDouble extends (Component as unknown as new (...args: never[]) => object) {}
+  setComponentTemplate(template as unknown as TemplateFactory, RenderingTestDouble);
+  return RenderingTestDouble as unknown as T;
+}

--- a/ember-native/src/test-support/with-template-for-testing.ts
+++ b/ember-native/src/test-support/with-template-for-testing.ts
@@ -1,6 +1,5 @@
-import { setComponentTemplate } from '@ember/component';
+import { getComponentTemplate, setComponentTemplate } from '@ember/component';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
-import type { TemplateFactory } from '@glimmer/interfaces';
 
 // A `<page>` only gets a working `.frame`/ActionBar when it is a direct
 // native child of a `<frame>` element (see `dom/native/FrameElement.ts`) -
@@ -12,10 +11,20 @@ import type { TemplateFactory } from '@glimmer/interfaces';
 // `setComponentTemplate` is the supported way to swap in a test-only
 // template (e.g. the same content with the `<page>`/`<action-bar>` wrapper
 // removed) while keeping the original class's services, args, and lifecycle.
+//
+// A standalone `<template>...</template>` expression (as opposed to one
+// attached to a class) compiles to an already-complete
+// `TemplateOnlyComponent`, not the raw `TemplateFactory` `setComponentTemplate`
+// expects - `getComponentTemplate` pulls that factory back out so it can be
+// reattached to `Component`'s subclass.
 export function withTemplateForTest<
   T extends abstract new (...args: never[]) => object,
 >(Component: T, template: TemplateOnlyComponent<unknown>): T {
   class RenderingTestDouble extends (Component as unknown as new (...args: never[]) => object) {}
-  setComponentTemplate(template as unknown as TemplateFactory, RenderingTestDouble);
+  const factory = getComponentTemplate(template);
+  if (!factory) {
+    throw new Error('withTemplateForTest: could not resolve a template factory from `template`.');
+  }
+  setComponentTemplate(factory, RenderingTestDouble);
   return RenderingTestDouble as unknown as T;
 }


### PR DESCRIPTION
## Summary
- Rendering tests for components that render a root `<page>` element couldn't use `setupRenderingTest` as-is: `<page>` only gets a working `.frame`/`<action-bar>` when it's a direct native child of a `<frame>` element, which `setupRenderingTest` never provides - confirmed via CI, `TypeError: page.frame._getNavBarVisible is not a function`.
- A synthetic `<frame>` root (swapping the `ApplicationInstance`'s `rootElement` before `setupRenderingTest`'s `beforeEach` runs) was tried and ruled out via CI: Glimmer's marker-based insertion never routed the rendered `<page>` through `FrameElement`'s `Frame.navigate()` wiring.
- Added `withTemplateForTest` (`ember-native/test-support/with-template-for-testing`), which formalizes the "strip the `<page>` wrapper" pattern consumer apps were already reinventing per component: it uses `setComponentTemplate`/`getComponentTemplate` to swap in a test-only template on a subclass, keeping the original component's backing class (services, args, lifecycle) intact.
- Documented the pattern and the underlying constraint in the README under "Testing page-rooted components".
- Added `demo-app/app/tests/unit/page-test.gts`, a rendering test demonstrating the pattern end to end.

## Test plan
- [x] CI `test app` job (karma on Android emulator): `Executed 8 of 8 SUCCESS`, including the new page-rendering test alongside `basics-test`, `list-view-test`, `rad-list-view-test`, and `main-page-test`.
- [x] CI `build & lint` job passes (glint/eslint clean).