### PR TITLE
Fix broken default-export _app_ reexport stubs for index barrel files

### DIFF
--- a/ember-native/.gitignore
+++ b/ember-native/.gitignore
@@ -20,6 +20,8 @@
 !package.json
 !README.md
 !rollup.config.mjs
+!rollup-app-reexports-guard.js
+!rollup-app-reexports-guard.test.js
 !tsconfig.json
 !.npmrc
 !eslint

--- a/ember-native/package.json
+++ b/ember-native/package.json
@@ -37,7 +37,7 @@
     "start:types": "glint --declaration --watch",
     "debug:types": "glint --debug-intermediate-representation",
     "prepack": "pnpm build",
-    "test": "node --test utils/*.test.js src/dom/native/*.test.ts"
+    "test": "node --test utils/*.test.js src/dom/native/*.test.ts *.test.js"
   },
   "peerDependencies": {
     "@glimmer/component": "*",
@@ -159,9 +159,7 @@
       "./components/ember-native/InspectorSupport.js": "./dist/_app_/components/ember-native/InspectorSupport.js",
       "./components/ember-native/ListView.js": "./dist/_app_/components/ember-native/ListView.js",
       "./components/ember-native/RadListView.js": "./dist/_app_/components/ember-native/RadListView.js",
-      "./components/ember-native/index.js": "./dist/_app_/components/ember-native/index.js",
       "./instance-initializers/ember-native/history.js": "./dist/_app_/instance-initializers/ember-native/history.js",
-      "./modifiers/ember-native/index.js": "./dist/_app_/modifiers/ember-native/index.js",
       "./modifiers/ember-native/native-slot.js": "./dist/_app_/modifiers/ember-native/native-slot.js",
       "./services/ember-native/history.js": "./dist/_app_/services/ember-native/history.js",
       "./services/ember-native/native-router.js": "./dist/_app_/services/ember-native/native-router.js"

--- a/ember-native/rollup-app-reexports-guard.js
+++ b/ember-native/rollup-app-reexports-guard.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// addon-dev's `appReexports()` (see rollup.config.mjs) always assumes the
+// module it's reexporting has a default export unless told otherwise, so a
+// stub like `export { default } from "ember-native/components/index"` gets
+// emitted even when the target only has named exports. That's silently
+// broken for any consumer that eagerly resolves these `_app_` stubs (e.g.
+// Vite's `import.meta.glob`-based classic module auto-registration) - it
+// fails to build because the named export it's re-exporting doesn't exist.
+//
+// This inspects Rollup's own `generateBundle` bundle map - which already
+// has each chunk's real `exports` list computed - to catch that class of
+// mistake (e.g. a future barrel/aggregator file added to one of
+// `appReexports()`'s include globs without excluding it) before it ships.
+//
+// Deliberately fails closed: in a real build every `_app_` stub is emitted
+// from `Object.keys(bundle)` by addon-dev's own plugin (see
+// rollup-app-reexports.js in @embroider/addon-dev), so its target is always
+// a key in that same `bundle` and its specifier always starts with this
+// package's own name - there's no legitimate case where a stub's shape or
+// target can't be resolved. If one shows up as `unrecognized` instead, that
+// means addon-dev's emitted stub format changed underneath this check (its
+// exact text - one space, double quotes, trailing semicolon - is
+// load-bearing for the regex below) and the check can no longer vouch for
+// anything, which must fail the build rather than silently pass.
+function analyzeAppReexports(bundle, packageName) {
+  const mismatches = [];
+  const unrecognized = [];
+  const prefix = `${packageName}/`;
+
+  for (const [fileName, file] of Object.entries(bundle)) {
+    if (!fileName.startsWith('_app_/') || file.type !== 'asset') continue;
+
+    const source = typeof file.source === 'string' ? file.source : file.source.toString('utf8');
+    const match = /^export \{([^}]*)\} from "([^"]+)";/.exec(source);
+    if (!match) {
+      unrecognized.push({
+        fileName,
+        reason: `stub source doesn't match the expected 'export { ... } from "...";' shape: ${source.slice(0, 200)}`,
+      });
+      continue;
+    }
+
+    const [, namesRaw, specifier] = match;
+    const names = namesRaw
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean);
+
+    if (!specifier.startsWith(prefix)) {
+      unrecognized.push({
+        fileName,
+        reason: `specifier "${specifier}" doesn't start with this package's own name ("${prefix}")`,
+      });
+      continue;
+    }
+
+    const targetFileName = `${specifier.slice(prefix.length)}.js`;
+    const target = bundle[targetFileName];
+    if (!target || target.type !== 'chunk') {
+      unrecognized.push({
+        fileName,
+        reason: `target "${targetFileName}" (resolved from specifier "${specifier}") isn't a chunk in this bundle`,
+      });
+      continue;
+    }
+
+    const missing = names.filter((name) => !target.exports.includes(name));
+    if (missing.length > 0) {
+      mismatches.push({ fileName, targetFileName, missing, targetExports: target.exports });
+    }
+  }
+
+  return { mismatches, unrecognized };
+}
+
+module.exports = { analyzeAppReexports };

--- a/ember-native/rollup-app-reexports-guard.test.js
+++ b/ember-native/rollup-app-reexports-guard.test.js
@@ -1,0 +1,107 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { analyzeAppReexports } = require('./rollup-app-reexports-guard.js');
+
+// Fixture-matches the real bug: `components/index.js` only has named
+// exports (see src/components/index.gts), but addon-dev's appReexports()
+// used to unconditionally emit `export { default }` stubs for it.
+test('flags a stub that reexports a default export the target module does not have', () => {
+  const bundle = {
+    '_app_/components/ember-native/index.js': {
+      type: 'asset',
+      source: 'export { default } from "ember-native/components/index";\n',
+    },
+    'components/index.js': {
+      type: 'chunk',
+      exports: ['ListView', 'RadListView', 'InspectorSupport'],
+    },
+  };
+
+  const { mismatches, unrecognized } = analyzeAppReexports(bundle, 'ember-native');
+
+  assert.deepEqual(unrecognized, []);
+  assert.equal(mismatches.length, 1);
+  assert.equal(mismatches[0].fileName, '_app_/components/ember-native/index.js');
+  assert.deepEqual(mismatches[0].missing, ['default']);
+});
+
+test('does not flag a stub whose reexported name matches the target module', () => {
+  const bundle = {
+    '_app_/components/ember-native/ListView.js': {
+      type: 'asset',
+      source: 'export { default } from "ember-native/components/ListView";\n',
+    },
+    'components/ListView.js': {
+      type: 'chunk',
+      exports: ['default'],
+    },
+  };
+
+  const { mismatches, unrecognized } = analyzeAppReexports(bundle, 'ember-native');
+
+  assert.deepEqual(mismatches, []);
+  assert.deepEqual(unrecognized, []);
+});
+
+test('does not flag a stub reexporting named bindings that do exist on the target', () => {
+  const bundle = {
+    '_app_/components/ember-native/index.js': {
+      type: 'asset',
+      source: 'export { ListView, RadListView } from "ember-native/components/index";\n',
+    },
+    'components/index.js': {
+      type: 'chunk',
+      exports: ['ListView', 'RadListView'],
+    },
+  };
+
+  const { mismatches, unrecognized } = analyzeAppReexports(bundle, 'ember-native');
+
+  assert.deepEqual(mismatches, []);
+  assert.deepEqual(unrecognized, []);
+});
+
+test('ignores non-_app_ assets and non-asset bundle entries', () => {
+  const bundle = {
+    'components/index.js': { type: 'chunk', exports: ['ListView'] },
+  };
+
+  const { mismatches, unrecognized } = analyzeAppReexports(bundle, 'ember-native');
+
+  assert.deepEqual(mismatches, []);
+  assert.deepEqual(unrecognized, []);
+});
+
+// Fails closed rather than silently passing: every "can't figure out this
+// stub" branch is treated as a build-breaking finding, not an ignorable
+// case, because in a real build every `_app_` stub's target is guaranteed
+// to be a key in the same bundle - see analyzeAppReexports' docstring.
+test('flags an _app_ stub whose target chunk cannot be resolved in the bundle', () => {
+  const bundle = {
+    '_app_/components/ember-native/orphan.js': {
+      type: 'asset',
+      source: 'export { default } from "ember-native/components/orphan";\n',
+    },
+  };
+
+  const { mismatches, unrecognized } = analyzeAppReexports(bundle, 'ember-native');
+
+  assert.deepEqual(mismatches, []);
+  assert.equal(unrecognized.length, 1);
+  assert.equal(unrecognized[0].fileName, '_app_/components/ember-native/orphan.js');
+});
+
+test('flags an _app_ stub whose source does not match the expected addon-dev output shape', () => {
+  const bundle = {
+    '_app_/components/ember-native/weird.js': {
+      type: 'asset',
+      source: '// not a reexport stub at all\n',
+    },
+  };
+
+  const { mismatches, unrecognized } = analyzeAppReexports(bundle, 'ember-native');
+
+  assert.deepEqual(mismatches, []);
+  assert.equal(unrecognized.length, 1);
+  assert.equal(unrecognized[0].fileName, '_app_/components/ember-native/weird.js');
+});

--- a/ember-native/rollup.config.mjs
+++ b/ember-native/rollup.config.mjs
@@ -4,16 +4,41 @@ import postcss from 'rollup-plugin-postcss';
 import { babel } from '@rollup/plugin-babel';
 import copy from 'rollup-plugin-copy';
 import { Addon } from '@embroider/addon-dev/rollup';
+import reexportsGuard from './rollup-app-reexports-guard.js';
 
 // rollup-plugin-astroturf mjs has wrong import specifiers...
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const astroturf = require('rollup-plugin-astroturf');
 
+const { analyzeAppReexports } = reexportsGuard;
+
 const addon = new Addon({
   srcDir: 'src',
   destDir: 'dist',
 });
+
+const assertAppReexportsMatchTargets = () => {
+  const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+  return {
+    name: 'assert-app-reexports-match-targets',
+    generateBundle(_options, bundle) {
+      const { mismatches, unrecognized } = analyzeAppReexports(bundle, pkg.name);
+      if (mismatches.length === 0 && unrecognized.length === 0) return;
+
+      const lines = [
+        ...mismatches.map(
+          (m) =>
+            `  "${m.fileName}" reexports [${m.missing.join(', ')}] from "${m.targetFileName}", but that module only exports: ${m.targetExports.join(', ') || '(nothing)'}`,
+        ),
+        ...unrecognized.map((u) => `  "${u.fileName}": ${u.reason}`),
+      ];
+      throw new Error(
+        `addon.appReexports() emitted _app_ stub(s) this check couldn't verify:\n${lines.join('\n')}`,
+      );
+    },
+  };
+};
 
 const rootImport = (options) => ({
   resolveId: (importee) => {
@@ -49,6 +74,17 @@ export default {
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
+    //
+    // `**/index.{js,ts,gts,gjs}` is excluded: today the only files matching
+    // that pattern are top-level barrel files (`components/index.gts`,
+    // `modifiers/index.ts`) that only re-export named bindings, not a
+    // default export. addon-dev unconditionally assumes every reexported
+    // file has a default export, so without this exclude it emits
+    // `export { default } from "..."` stubs for these too, referencing a
+    // default export that doesn't exist. This exclude is scoped to the
+    // current directory layout, not a general rule - if a colocated
+    // default-exporting component like `components/foo/index.gts` is ever
+    // added, this glob would need narrowing so it doesn't also swallow that.
     addon.appReexports(
       [
         'components/**/*.{js,ts,gts,gjs}',
@@ -59,6 +95,7 @@ export default {
         'instance-initializers/**/*.{js,ts}',
       ],
       {
+        exclude: ['**/index.{js,ts,gts,gjs}'],
         mapFilename: (fn) => {
           const parts = fn.split('/');
           parts.splice(1, 0, 'ember-native');
@@ -66,6 +103,13 @@ export default {
         },
       },
     ),
+
+    // Regression guard: fail the build if any `_app_` reexport stub claims
+    // an export that its target module doesn't actually have (e.g. the
+    // `export { default }` mismatch above). See
+    // rollup-app-reexports-guard.test.js for the fast, direct version of
+    // this same check.
+    assertAppReexportsMatchTargets(),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided

--- a/ember-native/rollup.config.mjs
+++ b/ember-native/rollup.config.mjs
@@ -75,16 +75,17 @@ export default {
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
     //
-    // `**/index.{js,ts,gts,gjs}` is excluded: today the only files matching
-    // that pattern are top-level barrel files (`components/index.gts`,
+    // `*/index.{js,ts,gts,gjs}` is excluded: today the only files matching
+    // that pattern are the top-level barrel files (`components/index.gts`,
     // `modifiers/index.ts`) that only re-export named bindings, not a
     // default export. addon-dev unconditionally assumes every reexported
     // file has a default export, so without this exclude it emits
     // `export { default } from "..."` stubs for these too, referencing a
-    // default export that doesn't exist. This exclude is scoped to the
-    // current directory layout, not a general rule - if a colocated
-    // default-exporting component like `components/foo/index.gts` is ever
-    // added, this glob would need narrowing so it doesn't also swallow that.
+    // default export that doesn't exist. The glob is scoped to a single
+    // path segment (top-level barrels only) so a colocated default-exporting
+    // component like `components/foo/index.gts` still gets reexported
+    // normally - it's matched against the pre-mapFilename bundle key
+    // (e.g. `components/index.js`), which is one segment deep for barrels.
     addon.appReexports(
       [
         'components/**/*.{js,ts,gts,gjs}',
@@ -95,7 +96,7 @@ export default {
         'instance-initializers/**/*.{js,ts}',
       ],
       {
-        exclude: ['**/index.{js,ts,gts,gjs}'],
+        exclude: ['*/index.{js,ts,gts,gjs}'],
         mapFilename: (fn) => {
           const parts = fn.split('/');
           parts.splice(1, 0, 'ember-native');


### PR DESCRIPTION
## Summary
- `rollup.config.mjs`'s `addon.appReexports()` include globs (`components/**/*.{js,ts,gts,gjs}`, `modifiers/**/*.{js,ts}`) also matched the `components/index.gts`/`modifiers/index.ts` barrel files, which only have named exports (`export { default as ListView } from './ListView.js'`, etc.). `@embroider/addon-dev`'s `appReexports()` always assumes a default export unless told otherwise, so it published `dist/_app_/components/ember-native/index.js` and `dist/_app_/modifiers/ember-native/index.js` doing `export { default } from "ember-native/components/index"` against modules that don't have one - a real packaging bug for any consumer that eagerly resolves `_app_` stubs (e.g. Vite `import.meta.glob`-based classic module auto-registration), reported as forcing a manual glob-exclusion workaround downstream.
- Fix: exclude `**/index.{js,ts,gts,gjs}` from `appReexports()` - an "index" barrel has no meaningful classic-resolver name to reexport anyway. This also shrinks the published `package.json`'s `ember-addon.app-js` map by the two now-removed bogus entries (an intentional, correct published-package change).
- Added a build-time regression guard (`rollup-app-reexports-guard.js`, wired into `rollup.config.mjs` as a `generateBundle` plugin) that inspects Rollup's own bundle map - each chunk already has a real computed `.exports` list - and fails the build if any `_app_` stub ever claims an export its target doesn't have. It fails closed (treats "can't parse/resolve this stub" as a build-breaking finding rather than silently skipping it), since a future `@embroider/addon-dev` version could change the emitted stub's exact text shape out from under the regex this relies on. Its `node --test` unit tests (`rollup-app-reexports-guard.test.js`) cover the mismatch case, the passing cases, and both fail-closed branches.

## Notes
- This repo's own `demo-app`/`docs-app` never hit this failure - they go through `@embroider/vite`'s compat-prebuild, not a hand-written `import.meta.glob`, which resolves these more permissively. Verified no regression: `demo-app`'s `vite build --mode production -- --env.android` succeeds identically before and after this change. The actual proof the reported failure is fixed is that the two broken stub files simply no longer exist in `dist/_app_/**`.
- Verified the guard actually fires: temporarily reverted the exclude and rebuilt - it threw a clear error naming the two broken stubs, then restored the fix.
- `pnpm test` (this package's `node --test` suite, which now includes the new guard tests) isn't wired into `.github/workflows/ci.yml` (only `pnpm lint` + `pnpm build` are) - the build-time guard in `rollup.config.mjs` is what actually enforces this in CI, the unit test is for fast local iteration.

## Test plan
- [x] `pnpm build` (from `ember-native/`) succeeds and no longer emits `dist/_app_/{components,modifiers}/ember-native/index.js`
- [x] `pnpm lint` (eslint + template-lint + glint, the actual CI gate) passes clean
- [x] `pnpm test` passes, including the new `rollup-app-reexports-guard.test.js` (6 tests)
- [x] Reverting the `exclude` and rebuilding causes the new guard to throw with a clear message, confirming it actually catches the regression
- [x] `demo-app`'s `vite build --mode production -- --env.android` succeeds unchanged before/after