### PR TITLE
Add maybeSetupInspectorSupport as the safe inspector-support entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ setupEmberNativeApp(ENV);
 ```
 
 `setupEmberNativeApp` installs ember-native's DOM shim, wires up Chrome
-DevTools support in dev builds only (tree-shaken out of release builds), and
-sets `ENV.rootElement` to the app's root native view.
+DevTools support in dev builds only via `maybeSetupInspectorSupport` (see
+below), and sets `ENV.rootElement` to the app's root native view.
 
 `app/app.js`'s `App` class extends `NativeApplication` instead of
 `@ember/application` directly - it's the same class otherwise, with your own
@@ -145,6 +145,41 @@ import { createNativeApplication } from 'ember-native';
 
 export default createNativeApplication(App, ENV);
 ```
+
+
+Chrome DevTools support
+------------------------------------------------------------------------------
+
+`setupEmberNativeApp` already wires up Chrome DevTools protocol support for
+you, so most apps don't need to think about this at all. It only matters if
+you have a custom entry point that doesn't go through `setupEmberNativeApp`
+(or you want to trigger inspector support separately, e.g. later than app
+boot) and need to call it yourself - use `maybeSetupInspectorSupport`:
+
+```ts
+import { maybeSetupInspectorSupport } from 'ember-native';
+import { ENV } from '~/config/env';
+
+maybeSetupInspectorSupport(ENV);
+```
+
+This is a no-op in release builds, tree-shaken out of the bundle entirely
+rather than merely skipped at runtime. That distinction matters: the module
+`maybeSetupInspectorSupport` loads under the hood
+(`ember-native/setup-inspector-support`) statically imports
+`@nativescript/core/debugger/webinspector-dom`, which throws the moment it's
+evaluated on NativeScript's plain (non-`-with-inspector`) release runtime.
+Because ES module imports are hoisted, wrapping a static `import` of that
+module in a runtime `if (__DEV__)` check doesn't help - the import still runs
+and crashes before the guard ever executes. `maybeSetupInspectorSupport`
+performs the import as a dynamic `import()` internally, gated on
+`import.meta.env.DEV`, so Rollup can prove the whole branch is dead code in a
+production build and drop it instead of merely deferring it. Prefer this
+helper over importing `ember-native/setup-inspector-support` directly -
+that module's own `setupInspectorSupport` export is only safe behind this
+exact dynamic-import pattern, and getting it wrong silently breaks every
+release build that imports the module path at all, even unconditionally at
+the top of an otherwise-unrelated file.
 
 
 Testing page-rooted components

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -114,8 +114,8 @@ setupEmberNativeApp(ENV);
 ```
 
 `setupEmberNativeApp` installs ember-native's DOM shim, wires up Chrome
-DevTools support in dev builds only (tree-shaken out of release builds), and
-sets `ENV.rootElement` to the app's root native view.
+DevTools support in dev builds only via `maybeSetupInspectorSupport` (see
+below), and sets `ENV.rootElement` to the app's root native view.
 
 `app/app.js`'s `App` class extends `NativeApplication` instead of
 `@ember/application` directly - it's the same class otherwise, with your own
@@ -145,6 +145,41 @@ import { createNativeApplication } from 'ember-native';
 
 export default createNativeApplication(App, ENV);
 ```
+
+
+Chrome DevTools support
+------------------------------------------------------------------------------
+
+`setupEmberNativeApp` already wires up Chrome DevTools protocol support for
+you, so most apps don't need to think about this at all. It only matters if
+you have a custom entry point that doesn't go through `setupEmberNativeApp`
+(or you want to trigger inspector support separately, e.g. later than app
+boot) and need to call it yourself - use `maybeSetupInspectorSupport`:
+
+```ts
+import { maybeSetupInspectorSupport } from 'ember-native';
+import { ENV } from '~/config/env';
+
+maybeSetupInspectorSupport(ENV);
+```
+
+This is a no-op in release builds, tree-shaken out of the bundle entirely
+rather than merely skipped at runtime. That distinction matters: the module
+`maybeSetupInspectorSupport` loads under the hood
+(`ember-native/setup-inspector-support`) statically imports
+`@nativescript/core/debugger/webinspector-dom`, which throws the moment it's
+evaluated on NativeScript's plain (non-`-with-inspector`) release runtime.
+Because ES module imports are hoisted, wrapping a static `import` of that
+module in a runtime `if (__DEV__)` check doesn't help - the import still runs
+and crashes before the guard ever executes. `maybeSetupInspectorSupport`
+performs the import as a dynamic `import()` internally, gated on
+`import.meta.env.DEV`, so Rollup can prove the whole branch is dead code in a
+production build and drop it instead of merely deferring it. Prefer this
+helper over importing `ember-native/setup-inspector-support` directly -
+that module's own `setupInspectorSupport` export is only safe behind this
+exact dynamic-import pattern, and getting it wrong silently breaks every
+release build that imports the module path at all, even unconditionally at
+the top of an otherwise-unrelated file.
 
 
 Testing page-rooted components

--- a/ember-native/src/index.ts
+++ b/ember-native/src/index.ts
@@ -1,5 +1,6 @@
 export { setup } from './setup.ts';
 export { setupEmberNativeApp } from './setup-app.ts';
+export { maybeSetupInspectorSupport } from './maybe-setup-inspector-support.ts';
 export { createNativeApplication } from './create-native-application.ts';
 export { NativeApplication } from './native-application.ts';
 export * from './components/index.gts';

--- a/ember-native/src/maybe-setup-inspector-support.ts
+++ b/ember-native/src/maybe-setup-inspector-support.ts
@@ -1,0 +1,41 @@
+/**
+ * Wires up Chrome DevTools protocol support in dev builds only, tree-shaken
+ * out of release builds entirely.
+ *
+ * `./setup-inspector-support.ts` statically imports
+ * `@nativescript/core/debugger/webinspector-dom`, and that module applies a
+ * `@DomainDispatcher('DOM')` decorator to a class at its own top level,
+ * immediately calling a `__registerDomainDispatcher` global that only the
+ * "-with-inspector" Android runtime variant provides - NativeScript's
+ * *release* builds intentionally use the plain runtime instead, so this
+ * throws a `ReferenceError` the moment the module is loaded, aborting app
+ * boot with a generic, cause-less "Module evaluation promise rejected" error,
+ * on every release build (see VITE_MIGRATION_NOTES.md). A plain runtime `if`
+ * around the *call* doesn't help, because ES import hoisting means the
+ * *import* already ran, unconditionally, by the time any runtime check could
+ * run. `import.meta.env.DEV` is a build-time constant Vite substitutes
+ * before tree-shaking, so unlike a runtime condition this one lets Rollup
+ * prove the branch (and everything only reachable through it, including the
+ * import) is dead code in a production build, and removes it from the bundle
+ * entirely instead of merely deferring it.
+ *
+ * Call this instead of importing `setup-inspector-support.ts` directly -
+ * that module's own `setupInspectorSupport` export is only safe to use
+ * behind this exact `import.meta.env.DEV`-gated dynamic-import pattern, and
+ * a plain static or unconditional import of it will crash every release
+ * build the moment that module is loaded.
+ */
+export function maybeSetupInspectorSupport(config: unknown): void {
+  if (import.meta.env.DEV) {
+    import('./setup-inspector-support.ts').then(({ setupInspectorSupport }) => {
+      try {
+        setupInspectorSupport(config);
+      } catch (e) {
+        console.error(
+          '[ember-native] setupInspectorSupport failed, devtools support will be unavailable:',
+          e,
+        );
+      }
+    });
+  }
+}

--- a/ember-native/src/setup-app.ts
+++ b/ember-native/src/setup-app.ts
@@ -1,38 +1,14 @@
 import { setup } from './setup.ts';
 import DocumentNode from './dom/nodes/DocumentNode.ts';
+import { maybeSetupInspectorSupport } from './maybe-setup-inspector-support.ts';
 
 export function setupEmberNativeApp(env: { rootElement: unknown; [key: string]: unknown }) {
   setup();
   (document as unknown as DocumentNode).config = env;
 
-  // Wiring up Chrome DevTools protocol support is a pure dev-tooling
-  // convenience, and `import.meta.env.DEV` must gate the *import*, not just
-  // the call: `./setup-inspector-support.ts` statically imports
-  // `@nativescript/core/debugger/webinspector-dom`, and that module applies a
-  // `@DomainDispatcher('DOM')` decorator to a class at its own top level,
-  // immediately calling a `__registerDomainDispatcher` global that only the
-  // "-with-inspector" Android runtime variant provides - NativeScript's
-  // *release* builds intentionally use the plain runtime instead, so this
-  // throws a `ReferenceError` the moment the module is loaded, aborting app
-  // boot with a generic, cause-less "Module evaluation promise rejected"
-  // error, on every release build (see VITE_MIGRATION_NOTES.md). A plain
-  // runtime `if` around the *call* (tried first) doesn't help, because ES
-  // import hoisting means the *import* already ran, unconditionally, by the
-  // time any runtime check could run. `import.meta.env.DEV` is a build-time
-  // constant Vite substitutes before tree-shaking, so unlike a runtime
-  // condition this one lets Rollup prove the branch (and everything only
-  // reachable through it, including the import) is dead code in a production
-  // build, and removes it from the bundle entirely instead of merely
-  // deferring it.
-  if (import.meta.env.DEV) {
-    import('./setup-inspector-support.ts').then(({ setupInspectorSupport }) => {
-      try {
-        setupInspectorSupport(env);
-      } catch (e) {
-        console.error('[ember-native] setupInspectorSupport failed, devtools support will be unavailable:', e);
-      }
-    });
-  }
+  // See maybe-setup-inspector-support.ts for why this can't be a plain
+  // static import or a runtime `if` around the call.
+  maybeSetupInspectorSupport(env);
 
   env.rootElement = DocumentNode.createElement('stack-layout');
 }


### PR DESCRIPTION
## Summary
- `setup-inspector-support.ts` statically imports `@nativescript/core/debugger/webinspector-dom`, which crashes on NativeScript's plain release runtime the moment the module is evaluated. It's only safe behind an `import.meta.env.DEV`-gated dynamic `import()` - a pattern that was previously only inlined in `setup-app.ts`, leaving any consumer with a custom entry point to rediscover and correctly reimplement the workaround themselves.
- Extracted that pattern into a new exported helper, `maybeSetupInspectorSupport(config)`, from the main entrypoint. `setup-app.ts` now calls it internally instead of duplicating the logic. `setup-inspector-support.ts` itself is unchanged and still directly reachable for consumers who already implement the guard correctly.
- Documented `maybeSetupInspectorSupport` in README.md as the recommended way to wire up inspector support for apps with a custom entry point that doesn't go through `setupEmberNativeApp`.

## Test plan
- [x] `pnpm build` (rollup + types) succeeds
- [x] `pnpm lint` (eslint, ember-template-lint, glint) passes
- [x] Built `demo-app` with a real production Vite build (`vite build --mode production -- --env.android`) and grepped `bundle.mjs`/`vendor.mjs` for `__registerDomainDispatcher`, `webinspector-dom`, `DomainDispatcher`, `setupInspectorSupport` - all absent, confirming the dynamic import is still fully tree-shaken out of release builds with the new helper in place