### PR TITLE
Patch nativescript-ui-listview 15.2.3 drag-reorder crash and drift

### DIFF
--- a/ember-native/.gitignore
+++ b/ember-native/.gitignore
@@ -7,6 +7,8 @@
 !lib/**/*
 !types
 !types/**/*
+!patches
+!patches/**/*
 !.eslintignore
 !.eslintrc.cjs
 !.gitignore

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -223,6 +223,49 @@ end-to-end instead, via `setupApplicationTest` + `visit()` (see
 app and its native `Application`.
 
 
+Known `nativescript-ui-listview` bugs (drag-reorder on Android)
+------------------------------------------------------------------------------
+
+`RadListView.gts` renders `<rad-list-view>` on top of
+[`nativescript-ui-listview`](https://github.com/NativeScript/plugins)'s
+`RadListView`/`ReorderWithHandlesBehavior`. As of `nativescript-ui-listview@15.2.3`
+(the version this package currently pins), Android's `reorderMode="Drag"`
+drag-and-drop reordering has two real upstream bugs:
+
+- A crash: `nsViewForItem.eachChildView` is called on `undefined` when a
+  `ViewHolder` is mid-recycle while a drag gesture starts (e.g. the bound
+  items array changes underneath an in-progress drag).
+- A UX bug: the drag image drifts horizontally instead of staying constrained
+  to vertical (Y-axis-only) movement, which is the expected behavior for a
+  vertically-scrolling list.
+
+Because `nativescript-ui-listview` is `ember-native`'s own dependency, every
+app using drag-reorder list views is exposed to both. pnpm's
+`patchedDependencies` isn't read from a published package's own
+`package.json` - only from the *installing* project's workspace root (see
+[pnpm/pnpm#8023](https://github.com/pnpm/pnpm/issues/8023)) - so this
+package's own patch (`ember-native/patches/nativescript-ui-listview@15.2.3.patch`,
+applied automatically within this monorepo) does not apply itself to a
+consumer app's install. If your app installs `nativescript-ui-listview`
+directly and uses drag-reorder, add the same patch to your own workspace
+root `package.json`:
+
+```json
+{
+  "pnpm": {
+    "patchedDependencies": {
+      "nativescript-ui-listview@15.2.3": "node_modules/ember-native/patches/nativescript-ui-listview@15.2.3.patch"
+    }
+  }
+}
+```
+
+Both bugs have also been reported upstream:
+[NativeScript/plugins#672](https://github.com/NativeScript/plugins/issues/672)
+- once a fixed release ships, this package's pin and patch will be dropped in
+favor of it.
+
+
 Contributing
 ------------------------------------------------------------------------------
 

--- a/ember-native/package.json
+++ b/ember-native/package.json
@@ -15,6 +15,7 @@
     "addon-main.cjs",
     "declarations",
     "dist",
+    "patches",
     "types"
   ],
   "bin": {

--- a/ember-native/patches/nativescript-ui-listview@15.2.3.patch
+++ b/ember-native/patches/nativescript-ui-listview@15.2.3.patch
@@ -1,0 +1,45 @@
+diff --git a/index.android.js b/index.android.js
+index e0e9a6f4483e2ec72236623874561d1b14a27381..77a24400768a8d2c319289dd504e2ac9ac2979ac 100644
+--- a/index.android.js
++++ b/index.android.js
+@@ -35,16 +35,33 @@ function ensureExtendedReorderWithHandlesBehavior() {
+         var reorderHandle = undefined;
+         if (nsOwner) {
+             var nsViewForItem = nsOwner._listViewAdapter.getViewForItem(nsOwner.getItemAtIndex(originalItemIndex));
+-            nsViewForItem.eachChildView(function (view) {
+-                if (view instanceof ReorderHandle) {
+-                    reorderHandle = view;
+-                    return false;
+-                }
+-                return true;
+-            });
++            // originalItemIndex can be RecyclerView.NO_POSITION (-1) - and nsViewForItem can be
++            // undefined - when the itemView's ViewHolder is mid-recycle/detached while a drag
++            // gesture starts. Patched: upstream called .eachChildView on nsViewForItem
++            // unconditionally, crashing with "Cannot read properties of undefined (reading
++            // 'eachChildView')".
++            if (nsViewForItem) {
++                nsViewForItem.eachChildView(function (view) {
++                    if (view instanceof ReorderHandle) {
++                        reorderHandle = view;
++                        return false;
++                    }
++                    return true;
++                });
++            }
+         }
+         return reorderHandle === undefined ? itemView : reorderHandle.nativeViewProtected;
+     };
++    // Patched: constrain the drag image to the y axis. Upstream's moveReorderImage(startX,
++    // startY, currentX, currentY) offsets the dragged item's bitmap by (currentX - startX,
++    // currentY - startY), so it drifts horizontally too. Pinning currentX to startX zeroes that
++    // delta while leaving vertical tracking untouched, which is the correct behavior for a
++    // vertically-scrolling list. This is the only live call site (onShortPressDrag, used by
++    // reorderMode="Drag"); ItemReorderBehavior's onLongPressDrag also calls moveReorderImage but
++    // is a no-op override in this class since "Drag" mode never uses long-press.
++    ExtendedReorderWithHandlesBehavior.prototype.moveReorderImage = function (startX, startY, currentX, currentY) {
++        _super.prototype.moveReorderImage.call(this, startX, startY, startX, currentY);
++    };
+     return ExtendedReorderWithHandlesBehavior;
+ }(com.telerik.widget.list.ReorderWithHandlesBehavior));
+     ExtendedReorderWithHandlesBehaviorClass = ExtendedReorderWithHandlesBehavior;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,10 @@
       "esbuild",
       "nativescript",
       "unrs-resolver"
-    ]
+    ],
+    "patchedDependencies": {
+      "nativescript-ui-listview@15.2.3": "ember-native/patches/nativescript-ui-listview@15.2.3.patch"
+    }
   },
   "packageManager": "pnpm@10.23.0",
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,11 @@ settings:
 overrides:
   '@embroider/addon-shim': 1.9.0
 
+patchedDependencies:
+  nativescript-ui-listview@15.2.3:
+    hash: b91189740b26ae7cc5b90d8f0e8201ededacf77e4cbec978e6ccc8d9151a4629
+    path: ember-native/patches/nativescript-ui-listview@15.2.3.patch
+
 importers:
 
   .:
@@ -102,7 +107,7 @@ importers:
         version: 4.7.0
       nativescript-ui-listview:
         specifier: ^15.2.3
-        version: 15.2.3
+        version: 15.2.3(patch_hash=b91189740b26ae7cc5b90d8f0e8201ededacf77e4cbec978e6ccc8d9151a4629)
       nativescript-ui-sidedrawer:
         specifier: ^15.2.3
         version: 15.2.3
@@ -223,7 +228,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-ember:
         specifier: ^12.3.1
-        version: 12.7.5(84740c278c3325a0cf2a0506dc099481)
+        version: 12.7.5(5ff893536b5be6763174ded7d398637d)
       eslint-plugin-n:
         specifier: ^17.23.1
         version: 17.24.0(0d62767105e9a39fc494591cb6137847)
@@ -894,7 +899,7 @@ importers:
         version: 4.7.0
       nativescript-ui-listview:
         specifier: ^15.2.3
-        version: 15.2.3
+        version: 15.2.3(patch_hash=b91189740b26ae7cc5b90d8f0e8201ededacf77e4cbec978e6ccc8d9151a4629)
       prettier:
         specifier: ^3.6.2
         version: 3.8.2
@@ -23827,19 +23832,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.0(0d62767105e9a39fc494591cb6137847)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
-      debug: 4.4.3(supports-color@9.4.0)
-      eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@typescript-eslint/parser@8.61.0(717face55a559967bf1b77f9b43bd1f1)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
@@ -28162,23 +28154,6 @@ snapshots:
       - eslint
       - typescript
 
-  ember-eslint-parser@0.5.13(84740c278c3325a0cf2a0506dc099481):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/eslint-parser': 7.28.6(35c79763e2f529503c5fce6757258eb9)
-      '@glimmer/syntax': 0.95.0
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
-      content-tag: 2.0.3
-      eslint-scope: 7.2.2
-      html-tags: 3.3.1
-      mathml-tag-names: 2.1.3
-      svg-tags: 1.0.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(0d62767105e9a39fc494591cb6137847)
-    transitivePeerDependencies:
-      - eslint
-      - typescript
-
   ember-eslint-parser@0.5.13(b21a5c2d82ffcddaa5ddcd8b5e86f59d):
     dependencies:
       '@babel/core': 7.29.0
@@ -29261,25 +29236,6 @@ snapshots:
       snake-case: 3.0.4
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(0d62767105e9a39fc494591cb6137847)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - typescript
-
-  eslint-plugin-ember@12.7.5(84740c278c3325a0cf2a0506dc099481):
-    dependencies:
-      '@ember-data/rfc395-data': 0.0.4
-      css-tree: 3.2.1
-      ember-eslint-parser: 0.5.13(84740c278c3325a0cf2a0506dc099481)
-      ember-rfc176-data: 0.3.18
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.6.1))
-      estraverse: 5.3.0
-      lodash.camelcase: 4.3.0
-      lodash.kebabcase: 4.1.1
-      requireindex: 1.2.0
-      snake-case: 3.0.4
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(0d62767105e9a39fc494591cb6137847)
     transitivePeerDependencies:
       - '@babel/core'
       - typescript
@@ -33098,7 +33054,7 @@ snapshots:
 
   nativescript-ui-core@15.2.3: {}
 
-  nativescript-ui-listview@15.2.3:
+  nativescript-ui-listview@15.2.3(patch_hash=b91189740b26ae7cc5b90d8f0e8201ededacf77e4cbec978e6ccc8d9151a4629):
     dependencies:
       nativescript-ui-core: 15.2.3
 


### PR DESCRIPTION
## Summary
- `RadListView`'s Android `reorderMode="Drag"` crashes with `Cannot read properties of undefined (reading 'eachChildView')` when a `ViewHolder` is mid-recycle as a drag gesture starts, and separately drifts the drag image horizontally instead of staying on the Y axis. Both are real bugs in `nativescript-ui-listview@15.2.3` itself, filed upstream as [NativeScript/plugins#672](https://github.com/NativeScript/plugins/issues/672).
- Adds `ember-native/patches/nativescript-ui-listview@15.2.3.patch` (verified applying via `pnpm patch`/`pnpm patch-commit` against the real installed tarball) and wires it into this repo's own `pnpm.patchedDependencies`, so this monorepo's demo-app/tests pick it up automatically.
- Ships the patch file inside the published package (`files` in `ember-native/package.json`) and documents in the README that consumer apps - which install `nativescript-ui-listview` themselves, since it's ember-native's runtime dependency for `RadListView` - need to add the same `patchedDependencies` entry pointing at `node_modules/ember-native/patches/...` in their own `package.json`. pnpm does not read `patchedDependencies` from a dependency's own `package.json` ([pnpm/pnpm#8023](https://github.com/pnpm/pnpm/issues/8023)), so this can't be fully automatic yet.

## Test plan
- [x] `pnpm install` at the workspace root applies the patch cleanly (no `ERR_PNPM_INVALID_PATCH`)
- [x] Confirmed the patched `moveReorderImage`/`eachChildView` guard is present in the installed `node_modules/.pnpm/nativescript-ui-listview@15.2.3.../index.android.js`
- [x] `prettier --check` clean on all changed files