### PR TITLE
Add regression test + docs for textContent after a native tap

### DIFF
--- a/demo-app/app/tests/unit/basics-test.gts
+++ b/demo-app/app/tests/unit/basics-test.gts
@@ -74,10 +74,7 @@ QUnit.module('Basics | rendering & modifier', function(hooks) {
     const toggle = () => {
       state.label = state.label === 'off' ? 'on' : 'off';
     };
-    await render(<template>
-      <button {{on 'tap' toggle}}>toggle</button>
-      <label text={{state.label}} />
-    </template>);
+    await render(<template><button {{on 'tap' toggle}}>toggle</button><label text={{state.label}} /></template>);
     assert.equal(this.element.textContent.trim(), 'toggle off');
 
     await click('button');

--- a/demo-app/app/tests/unit/basics-test.gts
+++ b/demo-app/app/tests/unit/basics-test.gts
@@ -49,4 +49,38 @@ QUnit.module('Basics | rendering & modifier', function(hooks) {
         await click('button');
         assert.equal(clicked, true);
     })
+
+  // Regression test for a reported timing bug: a consumer's tests had to read
+  // `getAttribute('text')` instead of `.textContent` right after tapping a native
+  // element, because `.textContent` was observed to intermittently read back stale
+  // (empty) text on a CI emulator. `click()` already awaits `settled()`, so if a
+  // native tap's resulting text update were deferred past that (a microtask, a
+  // native layout pass, etc.) this test would catch it.
+  //
+  // Uses a `<label>` whose `text` is a dynamic *attribute* binding, not a child
+  // `TextNode`: a child-`TextNode` case (e.g. `<button>counter: {{...}}</button>`,
+  // see the tests above) reads `TextNode`'s own plain `.text` field either way and
+  // wouldn't distinguish this from the bug fixed in #405 (`textContent` reading a
+  // native element's always-`undefined` plain `.text` field instead of going
+  // through `getAttribute`, which reflects the real native view property) - only
+  // an attribute-bound native element forces the read through
+  // `NativeElementNode#getAttribute` -> `nativeView.text`.
+  QUnit.test('textContent reflects an attribute-bound text change caused by a native tap, immediately after click() resolves', async function(this: RenderingTestContext, assert) {
+    class State {
+      @tracked label = 'off';
+    };
+
+    const state = new State();
+    const toggle = () => {
+      state.label = state.label === 'off' ? 'on' : 'off';
+    };
+    await render(<template>
+      <button {{on 'tap' toggle}}>toggle</button>
+      <label text={{state.label}} />
+    </template>);
+    assert.equal(this.element.textContent.trim(), 'toggle off');
+
+    await click('button');
+    assert.equal(this.element.textContent.trim(), 'toggle on');
+  });
 });

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -223,6 +223,35 @@ end-to-end instead, via `setupApplicationTest` + `visit()` (see
 app and its native `Application`.
 
 
+Reading text content in tests
+------------------------------------------------------------------------------
+
+`ViewNode#textContent` (`ember-native/src/dom/nodes/ViewNode.ts`) reads each
+leaf element's current `text`/`html` via `getAttribute`, which for a native
+element (`NativeElementNode#getAttribute`) reads the underlying native
+view's real, current property value - there is no microtask, native layout
+pass, or debounced write anywhere between a `text={{...}}` binding (or a
+child `TextNode` update) and the value `textContent` sees; the update is
+synchronous JS all the way down to the native property assignment. So
+`await click(...)`/`await rerender()` (which just await `settled()`) are
+always enough - `.textContent` does not need `getAttribute('text')` as a
+workaround after a tap or other interaction.
+
+Two things can still make `.textContent` look wrong if you're not expecting
+them, neither of which is a staleness bug:
+
+- Leaf contents are joined with a single space and empty/falsy segments are
+  dropped, so e.g. `<button>counter: {{state.counter}}</button>` reads back
+  as `'counter:  0'` (two spaces - `'counter: '` and `'0'` are separate text
+  nodes) rather than `'counter: 0'`.
+- `getAttribute` returns `null` for an element whose `nativeView` isn't set
+  (e.g. mid-teardown, or a recycled `ListView`/`RadListView` row between
+  native recycle callbacks) - that element silently contributes nothing to
+  `textContent` rather than throwing, so a query that happens to hit such an
+  element mid-recycle reads back a shorter string, not necessarily an
+  outright empty one.
+
+
 Contributing
 ------------------------------------------------------------------------------
 

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -231,25 +231,33 @@ leaf element's current `text`/`html` via `getAttribute`, which for a native
 element (`NativeElementNode#getAttribute`) reads the underlying native
 view's real, current property value - there is no microtask, native layout
 pass, or debounced write anywhere between a `text={{...}}` binding (or a
-child `TextNode` update) and the value `textContent` sees; the update is
-synchronous JS all the way down to the native property assignment. So
-`await click(...)`/`await rerender()` (which just await `settled()`) are
+child `TextNode` update) and the value `textContent` reads: a property
+write (NativeScript core's `Property.set`) always updates its JS-side
+cache, the thing `getAttribute`/`textContent` actually read, synchronously.
+So `await click(...)`/`await rerender()` (which just await `settled()`) are
 always enough - `.textContent` does not need `getAttribute('text')` as a
 workaround after a tap or other interaction.
 
-Two things can still make `.textContent` look wrong if you're not expecting
-them, neither of which is a staleness bug:
+A few things can still make `.textContent` look wrong if you're not
+expecting them, none of which is a staleness bug:
 
 - Leaf contents are joined with a single space and empty/falsy segments are
   dropped, so e.g. `<button>counter: {{state.counter}}</button>` reads back
   as `'counter:  0'` (two spaces - `'counter: '` and `'0'` are separate text
   nodes) rather than `'counter: 0'`.
+- Whitespace *between* elements in a template is itself a real, non-empty
+  text node and gets counted the same way: `<button>a</button>` and
+  `<label ... />` written on separate, indented lines read back with that
+  literal newline/indentation between them (e.g. `'a \n  b'`). Put sibling
+  elements on one line, with no whitespace between them, when asserting on
+  their combined `textContent`.
 - `getAttribute` returns `null` for an element whose `nativeView` isn't set
-  (e.g. mid-teardown, or a recycled `ListView`/`RadListView` row between
-  native recycle callbacks) - that element silently contributes nothing to
-  `textContent` rather than throwing, so a query that happens to hit such an
-  element mid-recycle reads back a shorter string, not necessarily an
-  outright empty one.
+  (e.g. mid-teardown - `NativeElementNode`'s `ActionBar`/`ActionItem`
+  removal path has a case where `actionItems` is nulled out before removal
+  fires, see `onRemovedChild` in `NativeElementNode.ts`) - that element
+  silently contributes nothing to `textContent` rather than throwing, so a
+  query that happens to hit such an element mid-teardown reads back a
+  shorter string, not necessarily an outright empty one.
 
 
 Contributing


### PR DESCRIPTION
## Summary
- Investigated a report that `.textContent` intermittently read back stale (empty) text right after tapping a native element, forcing a consumer to fall back to `getAttribute('text')`.
- Traced the full update chain (tap dispatch → tracked update → Glimmer rerender → `TextNode.setText` → `NativeElementNode.updateText` → `setAttribute` → NativeScript's `Property` setter → native `setText`) and confirmed it's synchronous JS end-to-end - no microtask, layout pass, or debounce anywhere in it. `await click()`/`await rerender()` (which just await `settled()`) are always sufficient.
- The symptom matches the bug already fixed in #405 (`textContent` reading a native element's always-`undefined` plain `.text` field instead of going through `getAttribute`). Added a regression test using the exact shape that bug affected - an attribute-bound `<label text={{...}}>`, not a child `TextNode` (whose own plain `.text` field would read correctly either way and wouldn't discriminate between the two code paths) - read immediately after a native tap with no extra `rerender()` call.
- Documented `textContent`'s actual consistency guarantees in the README, including two non-staleness gotchas that can still make it look wrong (space-joined segments, and elements with no current `nativeView` silently contributing nothing).

## Test plan
- [x] `pnpm exec eslint` / `pnpm exec glint` clean on the touched files
- [x] `pnpm test` (ember-native package unit tests) passes
- [ ] `app test` CI job (Android emulator) passes, confirming the new regression test is green in the same environment where the staleness was reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)