### PR TITLE
Add DocumentNode.getElementsByTagName/querySelector so Vite's preload helper stops crashing

### DIFF
--- a/demo-app/app/tests/unit/document-node-test.gts
+++ b/demo-app/app/tests/unit/document-node-test.gts
@@ -13,16 +13,24 @@ import DocumentNode from 'ember-native/dom/nodes/DocumentNode';
 QUnit.module('DocumentNode | browser-DOM compatibility', function (hooks) {
   setupRenderingTest(hooks);
 
-  QUnit.test('getElementsByTagName returns a real array, empty for a tag nothing rendered', async function (this: RenderingTestContext, assert) {
-    await render(<template><button>hi</button></template>);
-
+  // `document.getElementsByTagName` only ever needs to search `document`'s
+  // own subtree (in practice just `document.head` - a rendering test's
+  // actual UI tree is never attached under `document` itself, only under
+  // its own detached test-container root), which is exactly what Vite's
+  // preload() helper searches too: it only ever looks for `<link>` tags it
+  // itself previously created and appended to `document.head`.
+  QUnit.test('getElementsByTagName returns a real array, finds elements appended under document.head, empty otherwise', function (assert) {
     const document = globalThis.document as unknown as DocumentNode;
-    const buttons = document.getElementsByTagName('button');
-    assert.ok(Array.isArray(buttons), 'returns a real array, not undefined');
-    assert.ok(buttons.length >= 1, 'finds the rendered <button>');
+
+    const link = document.createElement('link');
+    document.head.appendChild(link);
 
     const links = document.getElementsByTagName('link');
-    assert.deepEqual(links, [], 'a tag nothing rendered returns an empty array, not a crash');
+    assert.ok(Array.isArray(links), 'returns a real array, not undefined');
+    assert.ok(links.includes(link), 'finds the <link> appended under document.head');
+
+    const buttons = document.getElementsByTagName('button');
+    assert.deepEqual(buttons, [], 'a tag nothing was appended under document returns an empty array, not a crash');
   });
 
   QUnit.test('createElement tolerates browser-only tags (meta, link, title) instead of throwing', function (assert) {

--- a/demo-app/app/tests/unit/document-node-test.gts
+++ b/demo-app/app/tests/unit/document-node-test.gts
@@ -1,0 +1,65 @@
+import { setupRenderingTest } from '~/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { RenderingTestContext } from '@ember/test-helpers/setup-rendering-context';
+import DocumentNode from 'ember-native/dom/nodes/DocumentNode';
+
+// Regression coverage for consumer apps having to hand-write a `document`
+// shim (patching `getElementsByTagName`/`querySelector`/`createElement`)
+// purely so Vite's dynamic-import module-preload runtime helper doesn't
+// crash against ember-native's DocumentNode - even outside a real build,
+// since Vite's dev/test runtime probes the same APIs. See
+// node_modules/vite/dist/node/chunks/config.js's `preload()`/
+// `detectScriptRel()` for the exact sequence this mirrors.
+QUnit.module('DocumentNode | browser-DOM compatibility', function (hooks) {
+  setupRenderingTest(hooks);
+
+  QUnit.test('getElementsByTagName returns a real array, empty for a tag nothing rendered', async function (this: RenderingTestContext, assert) {
+    await render(<template><button>hi</button></template>);
+
+    const document = globalThis.document as unknown as DocumentNode;
+    const buttons = document.getElementsByTagName('button');
+    assert.ok(Array.isArray(buttons), 'returns a real array, not undefined');
+    assert.ok(buttons.length >= 1, 'finds the rendered <button>');
+
+    const links = document.getElementsByTagName('link');
+    assert.deepEqual(links, [], 'a tag nothing rendered returns an empty array, not a crash');
+  });
+
+  QUnit.test('createElement tolerates browser-only tags (meta, link, title) instead of throwing', function (assert) {
+    const document = globalThis.document as unknown as DocumentNode;
+
+    for (const tag of ['meta', 'link', 'title']) {
+      // A throw here fails the test on its own - no try/catch needed.
+      const el: any = document.createElement(tag);
+      assert.equal(typeof el.appendChild, 'function', `createElement('${tag}') returns a node with a real appendChild`);
+    }
+  });
+
+  QUnit.test("querySelector on document still resolves #id/.class lookups (e.g. @ember/test-helpers' #ember-testing)", async function (this: RenderingTestContext, assert) {
+    await render(<template><button id='hello'>hi</button></template>);
+
+    const document = globalThis.document as unknown as DocumentNode;
+    assert.equal(document.querySelector('#hello'), document.getElementById('hello'));
+  });
+
+  QUnit.test("mirrors Vite's own preload() runtime helper call sequence without crashing", function (assert) {
+    const document = globalThis.document as unknown as DocumentNode;
+
+    // detectScriptRel(): `document.createElement("link").relList` - a throw
+    // anywhere in this test fails it on its own, no try/catch needed.
+    const relList = document.createElement('link').relList;
+    assert.notOk(relList, "fake <link> has no relList, so detectScriptRel() falls back to 'preload' instead of throwing");
+
+    // preload(): getElementsByTagName/querySelector for an absent csp nonce meta tag
+    const links = document.getElementsByTagName('link');
+    assert.deepEqual(links, []);
+    const cspNonceMeta = document.querySelector('meta[property=csp-nonce]');
+    assert.equal(cspNonceMeta, null, 'an unrelated meta[...] lookup resolves to null, not the app config pseudo-element');
+
+    // preload(): create + append the actual <link rel="modulepreload"> tag
+    const link: any = document.createElement('link');
+    link.rel = 'modulepreload';
+    document.head.appendChild(link);
+    assert.ok(true, 'document.head.appendChild(link) does not throw');
+  });
+});

--- a/demo-app/app/tests/unit/document-node-test.gts
+++ b/demo-app/app/tests/unit/document-node-test.gts
@@ -10,27 +10,37 @@ import DocumentNode from 'ember-native/dom/nodes/DocumentNode';
 // since Vite's dev/test runtime probes the same APIs. See
 // node_modules/vite/dist/node/chunks/config.js's `preload()`/
 // `detectScriptRel()` for the exact sequence this mirrors.
+//
+// `document` is a real singleton shared across every test in the whole run
+// (see DocumentNode's constructor/`setup()`), not recreated per test - so
+// these tests append their own elements under `document.head` and remove
+// them again afterwards, rather than asserting exact "nothing else is
+// there" counts. They also avoid `assert.deepEqual` on anything that might
+// contain an ElementNode: QUnit's own failure-message dumper assumes a
+// standard DOM node shape (a `nodeName` string) that ElementNode doesn't
+// have (`tagName` only) - confirmed on-device that a *failing* deepEqual on
+// such a value crashes QUnit itself ("Cannot read properties of undefined
+// (reading 'toLowerCase')" inside QUnit's own `dump.parsers.node`) instead
+// of reporting a clean diff.
 QUnit.module('DocumentNode | browser-DOM compatibility', function (hooks) {
   setupRenderingTest(hooks);
 
-  // `document.getElementsByTagName` only ever needs to search `document`'s
-  // own subtree (in practice just `document.head` - a rendering test's
-  // actual UI tree is never attached under `document` itself, only under
-  // its own detached test-container root), which is exactly what Vite's
-  // preload() helper searches too: it only ever looks for `<link>` tags it
-  // itself previously created and appended to `document.head`.
-  QUnit.test('getElementsByTagName returns a real array, finds elements appended under document.head, empty otherwise', function (assert) {
+  QUnit.test('getElementsByTagName returns a real, live-searchable array', function (assert) {
     const document = globalThis.document as unknown as DocumentNode;
 
+    const before = document.getElementsByTagName('link').length;
     const link = document.createElement('link');
     document.head.appendChild(link);
+    try {
+      const links = document.getElementsByTagName('link');
+      assert.ok(Array.isArray(links), 'returns a real array, not undefined');
+      assert.equal(links.length, before + 1, 'finds the <link> just appended under document.head');
+      assert.ok(links.includes(link), 'the array actually contains the appended element');
+    } finally {
+      document.head.removeChild(link);
+    }
 
-    const links = document.getElementsByTagName('link');
-    assert.ok(Array.isArray(links), 'returns a real array, not undefined');
-    assert.ok(links.includes(link), 'finds the <link> appended under document.head');
-
-    const buttons = document.getElementsByTagName('button');
-    assert.deepEqual(buttons, [], 'a tag nothing was appended under document returns an empty array, not a crash');
+    assert.equal(document.getElementsByTagName('link').length, before, 'removing it again shrinks the result back down');
   });
 
   QUnit.test('createElement tolerates browser-only tags (meta, link, title) instead of throwing', function (assert) {
@@ -52,22 +62,29 @@ QUnit.module('DocumentNode | browser-DOM compatibility', function (hooks) {
 
   QUnit.test("mirrors Vite's own preload() runtime helper call sequence without crashing", function (assert) {
     const document = globalThis.document as unknown as DocumentNode;
+    const before = document.getElementsByTagName('link').length;
 
     // detectScriptRel(): `document.createElement("link").relList` - a throw
     // anywhere in this test fails it on its own, no try/catch needed.
     const relList = document.createElement('link').relList;
     assert.notOk(relList, "fake <link> has no relList, so detectScriptRel() falls back to 'preload' instead of throwing");
 
-    // preload(): getElementsByTagName/querySelector for an absent csp nonce meta tag
-    const links = document.getElementsByTagName('link');
-    assert.deepEqual(links, []);
+    // preload(): querySelector for an absent csp nonce meta tag
     const cspNonceMeta = document.querySelector('meta[property=csp-nonce]');
-    assert.equal(cspNonceMeta, null, 'an unrelated meta[...] lookup resolves to null, not the app config pseudo-element');
+    assert.notOk(cspNonceMeta, 'an unrelated meta[...] lookup resolves to a falsy value, not the app config pseudo-element');
 
     // preload(): create + append the actual <link rel="modulepreload"> tag
     const link: any = document.createElement('link');
     link.rel = 'modulepreload';
     document.head.appendChild(link);
-    assert.ok(true, 'document.head.appendChild(link) does not throw');
+    try {
+      assert.equal(
+        document.getElementsByTagName('link').length,
+        before + 1,
+        'document.head.appendChild(link) does not throw and is reflected by getElementsByTagName',
+      );
+    } finally {
+      document.head.removeChild(link);
+    }
   });
 });

--- a/ember-native/src/dom/nodes/DocumentNode.ts
+++ b/ember-native/src/dom/nodes/DocumentNode.ts
@@ -1,4 +1,4 @@
-import { createElement } from '../element-registry.ts';
+import { createElement, isKnownView, normalizeElementName } from '../element-registry.ts';
 import CommentNode from './CommentNode.ts';
 import ElementNode from './ElementNode.ts';
 import PropertyNode from './PropertyNode.ts';
@@ -98,6 +98,19 @@ export default class DocumentNode extends ViewNode {
   ): NativeElementsTagNameMap[T] {
     if (tagName === 'property') {
       return this.createPropertyNode(tagName) as any;
+    }
+    if (!isKnownView(tagName)) {
+      // Browser-only tags (`meta`, `link`, `title`, ...) have no native
+      // NativeScript counterpart and were never meant to be rendered - but
+      // Vite's own runtime (the `__vitePreload` module-preload helper, run
+      // for every dynamic import) creates/queries them unconditionally, the
+      // same way it would against a real browser `document`. Throwing here
+      // crashed that generic code path; an inert element that just
+      // participates harmlessly in the tree (no native view, never
+      // rendered) is enough to satisfy it.
+      const e = new ElementNode(tagName as string);
+      e._ownerDocument = this.getInstance();
+      return e as any;
     }
     const e = createElement(tagName);
     e._ownerDocument = this.getInstance();
@@ -223,8 +236,19 @@ export default class DocumentNode extends ViewNode {
     };
   }
 
+  // Fakes the single `<meta name=".../config/environment" content="...">`
+  // tag `@embroider/config-meta-loader`/ember-cli's classic
+  // `app-config-from-meta.js` read config from in a real browser DOM - there
+  // is no such tag here (NativeScript has no HTML `<head>` to serialize one
+  // into), so `setupEmberNativeApp` stashes the raw config object on
+  // `this.config` instead (see `setup-app.ts`) and this fakes the lookup.
+  // Matched by substring, not `selector.startsWith('meta')`: a broader match
+  // would also swallow unrelated `meta[...]` lookups (e.g. Vite's own
+  // `meta[property=csp-nonce]` probe in its module-preload runtime helper)
+  // and hand back this app's entire config as a fake attribute value instead
+  // of correctly reporting "no such element".
   querySelectorAll(selector: string) {
-    if (selector.startsWith('meta')) {
+    if (selector.includes('config/environment')) {
       const config = this.config;
       return {
         getAttribute(): string {
@@ -232,5 +256,36 @@ export default class DocumentNode extends ViewNode {
         },
       };
     }
+  }
+
+  // Overrides `ViewNode#querySelector` only for the `meta` pseudo-element
+  // faked by `querySelectorAll` above - needed because the real caller
+  // (`@embroider/config-meta-loader`/ember-cli's classic config loading)
+  // uses the singular `querySelector`, not `querySelectorAll`. Everything
+  // else (`#id`, `.class`, plain tag names - including
+  // `@ember/test-helpers`' own `document.querySelector('#ember-testing')`,
+  // and any other `meta[...]` lookup that isn't the config tag) falls
+  // through to the real tree-walking implementation inherited from
+  // `ViewNode`.
+  querySelector(selector: string) {
+    return this.querySelectorAll(selector) || super.querySelector(selector);
+  }
+
+  // Vite's runtime module-preload helper (run for every dynamic import, in
+  // both dev and prod) calls `document.getElementsByTagName('link')`
+  // unconditionally to dedupe already-injected preload links - unlike
+  // `querySelector`/`querySelectorAll`, nothing on `ViewNode` provided a
+  // plural, list-returning tag lookup (only the singular
+  // `getElementByTagName`), so this always threw `TypeError:
+  // document.getElementsByTagName is not a function`.
+  getElementsByTagName(tagName: string) {
+    const normalizedTagName = normalizeElementName(tagName);
+    const results: ViewNode[] = [];
+    for (const el of elementIterator(this)) {
+      if (el.nodeType === 1 && el.tagName === normalizedTagName) {
+        results.push(el);
+      }
+    }
+    return results;
   }
 }


### PR DESCRIPTION
## Summary
- `DocumentNode` only implemented the singular `getElementByTagName` and had no `querySelector` override, and `createElement` threw for any tag with no native NativeScript counterpart (`meta`, `link`, `title`, ...). Vite's own runtime module-preload helper (`__vitePreload`, run for every dynamic import in dev *and* prod - see `preload()`/`detectScriptRel()` in `vite/dist/node/chunks/config.js`) calls `document.getElementsByTagName`/`querySelector`/`createElement` unconditionally, the same way it would against a real browser DOM - so every ember-native consumer app had to hand-write its own `document` shim working around this.
- Added `DocumentNode#getElementsByTagName` (a real tree walk, returns a possibly-empty array) and `DocumentNode#querySelector` (falls through to `ViewNode`'s real `#id`/`.class`/tag-name tree walk for everything except the app-config `meta` pseudo-element `querySelectorAll` already faked - tightened that match from a broad `startsWith('meta')` to specifically `config/environment`, so it no longer also swallows unrelated `meta[...]` lookups like Vite's own csp-nonce probe).
- `createElement` now returns an inert stub node for tags with no known native view (e.g. `meta`/`link`/`title`) instead of throwing.

## Test plan
- [x] `pnpm build` / `pnpm exec glint` / `pnpm exec eslint .` clean in both `ember-native/` and `demo-app/`
- [x] `pnpm test` (ember-native's own `node --test` suite) still passes
- [x] Added `demo-app/app/tests/unit/document-node-test.gts`, exercising the previously-missing methods directly and mirroring Vite's own `preload()` call sequence against the real `document` global
- [ ] CI (Android emulator karma run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)