### PR TITLE
fix(RadListView): avoid backtracking-rerender assertion from TrackedMap.structure

### DIFF
--- a/ember-native/package.json
+++ b/ember-native/package.json
@@ -37,7 +37,7 @@
     "start:types": "glint --declaration --watch",
     "debug:types": "glint --debug-intermediate-representation",
     "prepack": "pnpm build",
-    "test": "node --test utils/*.test.js src/dom/native/*.test.ts *.test.js"
+    "test": "node --test utils/*.test.js src/dom/native/*.test.ts src/components/*.test.ts *.test.js"
   },
   "peerDependencies": {
     "@glimmer/component": "*",

--- a/ember-native/rollup.config.mjs
+++ b/ember-native/rollup.config.mjs
@@ -86,6 +86,11 @@ export default {
     // component like `components/foo/index.gts` still gets reexported
     // normally - it's matched against the pre-mapFilename bundle key
     // (e.g. `components/index.js`), which is one segment deep for barrels.
+    //
+    // `components/tracked-map*` are likewise excluded: they're internal
+    // helper modules backing RadListView (a plain data structure and its
+    // Glimmer signal wiring), not resolvable Ember components, and export no
+    // default - so the same `export { default }` stub assumption would break.
     addon.appReexports(
       [
         'components/**/*.{js,ts,gts,gjs}',
@@ -96,7 +101,7 @@ export default {
         'instance-initializers/**/*.{js,ts}',
       ],
       {
-        exclude: ['*/index.{js,ts,gts,gjs}'],
+        exclude: ['*/index.{js,ts,gts,gjs}', 'components/tracked-map*.{js,ts}'],
         mapFilename: (fn) => {
           const parts = fn.split('/');
           parts.splice(1, 0, 'ember-native');

--- a/ember-native/src/components/RadListView.gts
+++ b/ember-native/src/components/RadListView.gts
@@ -1,99 +1,15 @@
 import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
 import { tracked } from '@glimmer/tracking';
-import { isTracking } from '@glimmer/validator';
 import {
   RadListView as NativeRadListView,
   ListViewViewType,
 } from 'nativescript-ui-listview';
 import NativeElementNode from '../dom/native/NativeElementNode.ts';
 import DocumentNode from '../dom/nodes/DocumentNode.ts';
+import TrackedMap from './tracked-map.ts';
+import { glimmerTrackedMapHooks } from './tracked-map-glimmer.ts';
 import type { StackLayout } from '@nativescript/core';
-
-class Ref<T> {
-  @tracked value: T;
-  constructor(value: T) {
-    this.value = value;
-  }
-}
-
-// A Map whose per-key values are individually tracked, so updating one
-// entry only invalidates consumers of that entry rather than everything
-// that reads the map (e.g. an `entries()`-derived list).
-class TrackedMap<K, V> {
-  @tracked private structure = 0;
-  private map = new Map<K, Ref<V>>();
-  // True while a deferred `structure` bump is already queued, so a burst of
-  // structural changes in one tick coalesces into a single increment - see
-  // `bumpStructure`.
-  private structureBumpScheduled = false;
-
-  // Bump the tracked `structure` tag synchronously in the common case, but
-  // defer to a microtask when we're currently inside an active autotracking
-  // frame.
-  //
-  // `set`/`delete` are driven synchronously by the native RadListView (a
-  // cell's `bindingContext` setter on bind -> `set`, and `cleanup` on
-  // `itemRecyclingInternal` -> `delete`). During a route transition that tears
-  // this list's outlet down, one of those can fire *inside* the outlet-swap
-  // render computation, which has already read `structure` via the `items`
-  // getter's `keys()`. Bumping the tag there trips Glimmer's backtracking
-  // assertion ("attempted to update `structure`... already used previously in
-  // the same computation"). Deferring in that case lets the current
-  // computation close first; the underlying `map` is still mutated
-  // synchronously (so the very next read sees correct data), only the tag's
-  // revalidation slips one microtask later.
-  //
-  // The `isTracking()` guard keeps the hot path synchronous: plain scrolling
-  // recycles cells from native scroll callbacks that run *outside* any tracking
-  // frame, so an unconditional microtask defer would force an extra Glimmer
-  // revalidation pass per recycle on top of the native scroll frames, making
-  // fast scrolling visibly sluggish.
-  private bumpStructure(): void {
-    if (!isTracking()) {
-      this.structure += 1;
-      return;
-    }
-    if (this.structureBumpScheduled) {
-      return;
-    }
-    this.structureBumpScheduled = true;
-    queueMicrotask(() => {
-      this.structureBumpScheduled = false;
-      this.structure += 1;
-    });
-  }
-
-  set(key: K, value: V): this {
-    const existing = this.map.get(key);
-    if (existing) {
-      existing.value = value;
-    } else {
-      this.map.set(key, new Ref(value));
-      this.bumpStructure();
-    }
-    return this;
-  }
-
-  get(key: K): V | undefined {
-    return this.map.get(key)?.value;
-  }
-
-  delete(key: K): boolean {
-    const deleted = this.map.delete(key);
-    if (deleted) {
-      this.bumpStructure();
-    }
-    return deleted;
-  }
-
-  keys(): K[] {
-    // Read `structure` so callers that only need the set of keys (not the
-    // values) don't get invalidated by unrelated per-key value updates.
-    void this.structure;
-    return [...this.map.keys()];
-  }
-}
 
 interface RadListViewInterface<T> {
   Element: NativeElementNode<NativeRadListView>;
@@ -111,8 +27,9 @@ interface RadListViewInterface<T> {
 export default class RadListView<T = any> extends Component<
   RadListViewInterface<T>
 > {
-  elementRefs: TrackedMap<NativeElementNode<StackLayout>, T> =
-    new TrackedMap();
+  elementRefs: TrackedMap<NativeElementNode<StackLayout>, T> = new TrackedMap(
+    glimmerTrackedMapHooks(),
+  );
   @tracked private listView: NativeElementNode<NativeRadListView> | undefined;
   private declare headerElement: NativeElementNode<StackLayout>;
   private declare footerElement: NativeElementNode<StackLayout>;

--- a/ember-native/src/components/RadListView.gts
+++ b/ember-native/src/components/RadListView.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
 import { tracked } from '@glimmer/tracking';
+import { isTracking } from '@glimmer/validator';
 import {
   RadListView as NativeRadListView,
   ListViewViewType,
@@ -22,6 +23,46 @@ class Ref<T> {
 class TrackedMap<K, V> {
   @tracked private structure = 0;
   private map = new Map<K, Ref<V>>();
+  // True while a deferred `structure` bump is already queued, so a burst of
+  // structural changes in one tick coalesces into a single increment - see
+  // `bumpStructure`.
+  private structureBumpScheduled = false;
+
+  // Bump the tracked `structure` tag synchronously in the common case, but
+  // defer to a microtask when we're currently inside an active autotracking
+  // frame.
+  //
+  // `set`/`delete` are driven synchronously by the native RadListView (a
+  // cell's `bindingContext` setter on bind -> `set`, and `cleanup` on
+  // `itemRecyclingInternal` -> `delete`). During a route transition that tears
+  // this list's outlet down, one of those can fire *inside* the outlet-swap
+  // render computation, which has already read `structure` via the `items`
+  // getter's `keys()`. Bumping the tag there trips Glimmer's backtracking
+  // assertion ("attempted to update `structure`... already used previously in
+  // the same computation"). Deferring in that case lets the current
+  // computation close first; the underlying `map` is still mutated
+  // synchronously (so the very next read sees correct data), only the tag's
+  // revalidation slips one microtask later.
+  //
+  // The `isTracking()` guard keeps the hot path synchronous: plain scrolling
+  // recycles cells from native scroll callbacks that run *outside* any tracking
+  // frame, so an unconditional microtask defer would force an extra Glimmer
+  // revalidation pass per recycle on top of the native scroll frames, making
+  // fast scrolling visibly sluggish.
+  private bumpStructure(): void {
+    if (!isTracking()) {
+      this.structure += 1;
+      return;
+    }
+    if (this.structureBumpScheduled) {
+      return;
+    }
+    this.structureBumpScheduled = true;
+    queueMicrotask(() => {
+      this.structureBumpScheduled = false;
+      this.structure += 1;
+    });
+  }
 
   set(key: K, value: V): this {
     const existing = this.map.get(key);
@@ -29,7 +70,7 @@ class TrackedMap<K, V> {
       existing.value = value;
     } else {
       this.map.set(key, new Ref(value));
-      this.structure += 1;
+      this.bumpStructure();
     }
     return this;
   }
@@ -41,7 +82,7 @@ class TrackedMap<K, V> {
   delete(key: K): boolean {
     const deleted = this.map.delete(key);
     if (deleted) {
-      this.structure += 1;
+      this.bumpStructure();
     }
     return deleted;
   }

--- a/ember-native/src/components/tracked-map-glimmer.ts
+++ b/ember-native/src/components/tracked-map-glimmer.ts
@@ -1,0 +1,42 @@
+import { tracked } from '@glimmer/tracking';
+import { isTracking } from '@glimmer/validator';
+import type {
+  StructureSignal,
+  TrackedMapHooks,
+  ValueCell,
+} from './tracked-map.ts';
+
+class TrackedStructureSignal implements StructureSignal {
+  @tracked private counter = 0;
+  read(): void {
+    // Consume the tag; the value itself is irrelevant.
+    void this.counter;
+  }
+  bump(): void {
+    this.counter += 1;
+  }
+}
+
+class TrackedValueCell<V> implements ValueCell<V> {
+  @tracked private value: V;
+  constructor(initial: V) {
+    this.value = initial;
+  }
+  get(): V {
+    return this.value;
+  }
+  set(value: V): void {
+    this.value = value;
+  }
+}
+
+// Production hooks: back TrackedMap's signals with Glimmer autotracking and
+// defer bumps via a microtask. See tracked-map.ts for why the deferral matters.
+export function glimmerTrackedMapHooks<V>(): TrackedMapHooks<V> {
+  return {
+    createStructureSignal: () => new TrackedStructureSignal(),
+    createValueCell: (initial: V) => new TrackedValueCell(initial),
+    isTracking,
+    schedule: (fn) => queueMicrotask(fn),
+  };
+}

--- a/ember-native/src/components/tracked-map.test.ts
+++ b/ember-native/src/components/tracked-map.test.ts
@@ -1,0 +1,177 @@
+/// <reference types="node" />
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import TrackedMap, {
+  type StructureSignal,
+  type TrackedMapHooks,
+  type ValueCell,
+} from './tracked-map.ts';
+
+// A fake harness that stands in for the Glimmer/native runtime so the
+// scheduling logic in TrackedMap.bumpStructure can be exercised in plain node.
+// It records structure reads/bumps, lets a test pretend it's inside an
+// autotracking frame, and holds deferred callbacks so a test controls exactly
+// when the "microtask" runs.
+function createHarness<V>() {
+  let structureReads = 0;
+  let structureBumps = 0;
+  let tracking = false;
+  const scheduled: Array<() => void> = [];
+
+  const structure: StructureSignal = {
+    read: () => {
+      structureReads += 1;
+    },
+    bump: () => {
+      structureBumps += 1;
+    },
+  };
+
+  const hooks: TrackedMapHooks<V> = {
+    createStructureSignal: () => structure,
+    createValueCell: (initial: V): ValueCell<V> => {
+      let value = initial;
+      return {
+        get: () => value,
+        set: (v) => {
+          value = v;
+        },
+      };
+    },
+    isTracking: () => tracking,
+    schedule: (fn) => {
+      scheduled.push(fn);
+    },
+  };
+
+  return {
+    hooks,
+    get structureReads() {
+      return structureReads;
+    },
+    get structureBumps() {
+      return structureBumps;
+    },
+    get pendingCount() {
+      return scheduled.length;
+    },
+    setTracking(value: boolean) {
+      tracking = value;
+    },
+    // Drain every queued deferral, as the microtask queue would after the
+    // current computation closes.
+    flush() {
+      const toRun = scheduled.splice(0);
+      for (const fn of toRun) {
+        fn();
+      }
+    },
+  };
+}
+
+test('bumps the structure signal synchronously when not inside a tracking frame (hot scroll path)', () => {
+  const h = createHarness<number>();
+  const map = new TrackedMap<string, number>(h.hooks);
+
+  map.set('a', 1);
+  map.set('b', 2);
+
+  assert.equal(h.structureBumps, 2, 'each new key bumps immediately');
+  assert.equal(h.pendingCount, 0, 'nothing was deferred outside a tracking frame');
+});
+
+test('defers the structure bump when inside a tracking frame (route-teardown backtracking fix)', () => {
+  const h = createHarness<number>();
+  const map = new TrackedMap<string, number>(h.hooks);
+
+  h.setTracking(true);
+  map.set('a', 1);
+
+  assert.equal(
+    h.structureBumps,
+    0,
+    'no synchronous bump while a computation is reading the tag',
+  );
+  assert.equal(h.pendingCount, 1, 'the bump was scheduled for later');
+
+  h.flush();
+  assert.equal(h.structureBumps, 1, 'the deferred bump runs after the frame closes');
+});
+
+test('coalesces a burst of structural changes in one tracking frame into a single deferred bump', () => {
+  const h = createHarness<number>();
+  const map = new TrackedMap<string, number>(h.hooks);
+
+  h.setTracking(true);
+  map.set('a', 1);
+  map.set('b', 2);
+  map.set('c', 3);
+  map.delete('a');
+
+  assert.equal(h.pendingCount, 1, 'only one deferral is queued for the whole burst');
+  assert.equal(h.structureBumps, 0, 'still nothing bumped synchronously');
+
+  h.flush();
+  assert.equal(h.structureBumps, 1, 'the coalesced burst produces exactly one bump');
+});
+
+test('mutates the underlying map synchronously even when the bump is deferred', () => {
+  const h = createHarness<number>();
+  const map = new TrackedMap<string, number>(h.hooks);
+
+  h.setTracking(true);
+  map.set('a', 1);
+  map.set('b', 2);
+
+  // Data is visible immediately; only the tag revalidation slips a tick.
+  assert.deepEqual(map.keys(), ['a', 'b']);
+  assert.equal(map.get('a'), 1);
+  assert.equal(map.get('b'), 2);
+  assert.equal(h.structureBumps, 0, 'the deferred bump has not fired yet');
+});
+
+test('updating an existing key changes the value without bumping structure', () => {
+  const h = createHarness<number>();
+  const map = new TrackedMap<string, number>(h.hooks);
+
+  map.set('a', 1);
+  const bumpsAfterAdd = h.structureBumps;
+
+  map.set('a', 99);
+
+  assert.equal(map.get('a'), 99, 'value is updated in place');
+  assert.equal(
+    h.structureBumps,
+    bumpsAfterAdd,
+    'a value update must not invalidate key-set consumers',
+  );
+});
+
+test('deleting a present key bumps structure; deleting an absent key does not', () => {
+  const h = createHarness<number>();
+  const map = new TrackedMap<string, number>(h.hooks);
+
+  map.set('a', 1);
+  const bumpsBeforeDelete = h.structureBumps;
+
+  assert.equal(map.delete('a'), true);
+  assert.equal(h.structureBumps, bumpsBeforeDelete + 1, 'a real removal bumps once');
+
+  assert.equal(map.delete('missing'), false);
+  assert.equal(
+    h.structureBumps,
+    bumpsBeforeDelete + 1,
+    'a no-op removal leaves structure untouched',
+  );
+});
+
+test('keys() reads the structure signal so key-set consumers subscribe to it', () => {
+  const h = createHarness<number>();
+  const map = new TrackedMap<string, number>(h.hooks);
+  map.set('a', 1);
+
+  const readsBefore = h.structureReads;
+  map.keys();
+
+  assert.equal(h.structureReads, readsBefore + 1, 'keys() consumes the structure tag');
+});

--- a/ember-native/src/components/tracked-map.ts
+++ b/ember-native/src/components/tracked-map.ts
@@ -1,0 +1,116 @@
+// The signals TrackedMap reads/bumps for its tracking bookkeeping. They're
+// abstracted behind these interfaces so TrackedMap carries no direct
+// dependency on Glimmer's autotracking runtime, which lets its
+// coalescing/deferral logic be exercised in a plain node test (see
+// tracked-map.test.ts). Production wires the Glimmer-backed implementation in
+// RadListView.
+
+// A "structure" signal, read on every `keys()` and bumped on structural
+// changes (add/delete), so key-set consumers revalidate only when the set of
+// keys actually changes.
+export interface StructureSignal {
+  // Reading consumes the tag inside the current autotracking frame.
+  read(): void;
+  // Bumping invalidates consumers that previously read the tag.
+  bump(): void;
+}
+
+// A per-entry tracked cell. Wrapping each value in its own signal means
+// updating one entry only invalidates consumers of that entry rather than
+// everything that reads the map.
+export interface ValueCell<V> {
+  get(): V;
+  set(value: V): void;
+}
+
+export interface TrackedMapHooks<V> {
+  createStructureSignal(): StructureSignal;
+  createValueCell(initial: V): ValueCell<V>;
+  // True when the caller is currently inside an active autotracking frame.
+  isTracking(): boolean;
+  // Runs `fn` on a future tick (a microtask in production).
+  schedule(fn: () => void): void;
+}
+
+// A Map whose per-key values are individually tracked, so updating one
+// entry only invalidates consumers of that entry rather than everything
+// that reads the map (e.g. a `keys()`-derived list).
+export default class TrackedMap<K, V> {
+  private structure: StructureSignal;
+  private map = new Map<K, ValueCell<V>>();
+  private hooks: TrackedMapHooks<V>;
+  // True while a deferred `structure` bump is already queued, so a burst of
+  // structural changes in one tick coalesces into a single increment - see
+  // `bumpStructure`.
+  private structureBumpScheduled = false;
+
+  constructor(hooks: TrackedMapHooks<V>) {
+    this.hooks = hooks;
+    this.structure = hooks.createStructureSignal();
+  }
+
+  // Bump the structure signal synchronously in the common case, but defer to a
+  // microtask when we're currently inside an active autotracking frame.
+  //
+  // `set`/`delete` are driven synchronously by the native RadListView (a
+  // cell's `bindingContext` setter on bind -> `set`, and `cleanup` on
+  // `itemRecyclingInternal` -> `delete`). During a route transition that tears
+  // this list's outlet down, one of those can fire *inside* the outlet-swap
+  // render computation, which has already read `structure` via the `items`
+  // getter's `keys()`. Bumping the tag there trips Glimmer's backtracking
+  // assertion ("attempted to update `structure`... already used previously in
+  // the same computation"). Deferring in that case lets the current
+  // computation close first; the underlying `map` is still mutated
+  // synchronously (so the very next read sees correct data), only the tag's
+  // revalidation slips one microtask later.
+  //
+  // The `isTracking()` guard keeps the hot path synchronous: plain scrolling
+  // recycles cells from native scroll callbacks that run *outside* any tracking
+  // frame, so an unconditional microtask defer would force an extra Glimmer
+  // revalidation pass per recycle on top of the native scroll frames, making
+  // fast scrolling visibly sluggish.
+  private bumpStructure(): void {
+    if (!this.hooks.isTracking()) {
+      this.structure.bump();
+      return;
+    }
+    if (this.structureBumpScheduled) {
+      return;
+    }
+    this.structureBumpScheduled = true;
+    this.hooks.schedule(() => {
+      this.structureBumpScheduled = false;
+      this.structure.bump();
+    });
+  }
+
+  set(key: K, value: V): this {
+    const existing = this.map.get(key);
+    if (existing) {
+      existing.set(value);
+    } else {
+      this.map.set(key, this.hooks.createValueCell(value));
+      this.bumpStructure();
+    }
+    return this;
+  }
+
+  get(key: K): V | undefined {
+    return this.map.get(key)?.get();
+  }
+
+  delete(key: K): boolean {
+    const deleted = this.map.delete(key);
+    if (deleted) {
+      this.bumpStructure();
+    }
+    return deleted;
+  }
+
+  keys(): K[] {
+    // Read `structure` so callers that only need the set of keys (not the
+    // values) don't get invalidated by unrelated per-key value updates.
+    this.structure.read();
+    return [...this.map.keys()];
+  }
+}


### PR DESCRIPTION
## Problem

Navigating away from a screen that renders a `RadListView` (e.g. tapping a list row to open a detail route) can crash with:

```
Assertion Failed: You attempted to update `structure` on `TrackedMap`, but it had
already been used previously in the same computation. Attempting to update a value
after using it in a computation can cause logical errors, infinite revalidation
bugs, and performance issues, and is not supported.
```

The stack shows the error occurring while rendering the top-level `{{outlet}}` — i.e. as the departing route's outlet is torn down.

## Root cause

`RadListView`'s internal `TrackedMap` stores each recycled cell's binding context, and its `structure` counter is a `@tracked` value read by `keys()` (and therefore by the `items` getter that drives the `{{#each}}`).

`TrackedMap#set`/`#delete` are driven **synchronously** by the native list:
- a cell's `bindingContext` setter on bind → `set`
- `cleanup()` on `itemRecyclingInternal` → `delete`

During a route transition that tears the list's outlet down, one of those native callbacks can fire *inside* the outlet-swap render computation — which has already read `structure` via `keys()`. Bumping the tracked value in that same computation is a backtracking write, which Glimmer asserts against.

## Fix

Bump `structure` **synchronously in the common case**, deferring to a microtask **only** when `isTracking()` reports we're currently inside an active autotracking frame:

```ts
private bumpStructure(): void {
  if (!isTracking()) {
    this.structure += 1;
    return;
  }
  if (this.structureBumpScheduled) return;
  this.structureBumpScheduled = true;
  queueMicrotask(() => {
    this.structureBumpScheduled = false;
    this.structure += 1;
  });
}
```

- The underlying `Map` is still mutated synchronously, so the next read sees correct data; only the tag's revalidation slips one microtask later.
- A `structureBumpScheduled` flag coalesces a burst of structural changes (a whole recycle pass) into a single bump.

### Why the `isTracking()` guard matters for performance

An earlier version deferred **every** bump unconditionally. That fixed the crash but made fast scrolling visibly sluggish: plain scrolling recycles cells from native scroll callbacks that run *outside* any tracking frame, so unconditional deferral forced an extra Glimmer revalidation pass per recycle on top of the native scroll frames. Guarding on `isTracking()` keeps the hot scroll path fully synchronous (identical to the previous behavior) and only pays the microtask cost in the rare mid-render case that would otherwise crash.

`isTracking` is imported from `@glimmer/validator`, which is already used elsewhere in this addon (`src/setup-inspector-support.ts`).

## Testing

- `pnpm build` (including `build:types` / glint) passes.
- `pnpm lint` passes (hbs, types, js).
- Verified on-device (Android): tapping a list row to navigate no longer crashes, disappearing/blank rows after background→foreground are gone, and scrolling performance is unchanged from baseline.