### PR TITLE
perf(RadListView): key rows by stable element, not item value

### DIFF
--- a/ember-native/src/components/RadListView.gts
+++ b/ember-native/src/components/RadListView.gts
@@ -48,10 +48,15 @@ export default class RadListView<T = any> extends Component<
   }
 
   get itemKey() {
-    if (this.args.key) {
-      return 'item.' + this.args.key;
-    }
-    return 'item';
+    // Key rows by the stable stack-layout element, not the item value.
+    // The native RadListView recycles a row by rebinding its bindingContext
+    // (-> `elementRefs.set(element, newItem)`), which changes the row's
+    // `item`. Keying by `item` would make Glimmer treat a recycled row as a
+    // brand-new one and tear down/rebuild its `{{#in-element}}` block every
+    // recycle (and risk duplicate keys when two rows transiently share a
+    // value). Keying by the element keeps the block mounted and reused - the
+    // per-row `item` getter drives the content update instead.
+    return 'element';
   }
 
   get items() {


### PR DESCRIPTION
Follow-up to #433 (which optimised \`ListView\`). Applies the same row-keying fix to \`RadListView\`.

## Problem

\`RadListView\` keyed its \`{{#each}}\` by the **item value** (\`'item'\` / \`'item.<key>'\`). But the native RadListView recycles a row by rebinding its \`bindingContext\` → \`elementRefs.set(element, newItem)\`, which changes that row's \`item\`. Keying by value makes Glimmer treat a recycled row as a brand-new one and **tear down / rebuild its \`{{#in-element}}\` block on every recycle** — the exact churn \`ListView\` avoids by keying on the element (#433) — and risks duplicate keys when two rows transiently share a value.

## Fix

Key by the stable stack-layout \`element\` instead (matching \`ListView.itemKey\`). The per-row \`item\` getter still drives the content update, so recycled rows keep their block mounted and just rebind. The \`@key\` arg becomes unused (same as \`ListView\`) but is kept in the interface for API compatibility.

## Validation

- ✅ \`glint\` typecheck passes
- ✅ 14/14 demo-app device tests on API 33 / arm64, including the RadListView test (content correct through add + full-replace cycles)

⚠️ Only ran on API 33 / arm64 locally. The change is behaviourally sound by construction (element identity is strictly more stable than value identity for recycling); a run on API 34 / x86_64 would fully close the loop.