### PR TITLE
perf(RadListView): keep cleanup off the hot recycle path, prune only on shrink

### DIFF
--- a/ember-native/src/components/RadListView.gts
+++ b/ember-native/src/components/RadListView.gts
@@ -35,6 +35,16 @@ export default class RadListView<T = any> extends Component<
   private declare footerElement: NativeElementNode<StackLayout>;
 
   cleanup(listView: NativeElementNode<NativeRadListView>) {
+    // Only sweep when there are more realized rows than items being displayed,
+    // i.e. the list actually shrank and left rows orphaned/window-detached.
+    // During steady-state scroll the realized-row count tracks the visible
+    // window and never exceeds `@items.length`, so this guard keeps the O(n)
+    // sweep - and the `elementRefs.delete` that dirties the TrackedMap's
+    // `structure` signal and re-diffs the whole `{{#each}}` - off the hot
+    // recycle path that caused fast-scroll lag.
+    if (this.elementRefs.size <= (this.args.items?.length ?? 0)) {
+      return;
+    }
     for (const element of this.elementRefs.keys()) {
       const n = element.nativeView.nativeViewProtected;
       if (!n || !n.getWindowToken()) {
@@ -81,17 +91,19 @@ export default class RadListView<T = any> extends Component<
     ) {
       this.listView = listView;
       const listViewComponent = this;
+      // Prune window-detached rows when the native list recycles cells. The
+      // `cleanup` guard makes this a cheap no-op during steady-state scroll
+      // (realized rows never exceed `@items.length`) and only performs the
+      // O(n) sweep + structure bump when the list actually shrank and left
+      // rows orphaned - e.g. `@items` going from 2 entries to 1. Without this,
+      // a shrink recycles a row without realizing a new element, so the stale
+      // row's content would linger in the tree.
+      listView.nativeView.on('itemRecyclingInternal', () => {
+        listViewComponent.cleanup(listView);
+      });
       function _getDefaultItemContent() {
-        // Prune any window-detached rows only when a new row element is actually being
-        // realized - matching ListView's `_getDefaultItemContent`. Previously `cleanup`
-        // was wired to fire on *every* `itemRecyclingInternal` event, i.e. on every cell
-        // recycle during a scroll, sweeping the whole `elementRefs` map each time (O(n) per
-        // recycle -> O(n^2) per screenful) and, whenever it deleted an entry, bumping the
-        // TrackedMap's `structure` signal - which re-runs the `items` getter's
-        // `keys().map()` and re-diffs the entire `{{#each}}`. That whole-list rebuild on the
-        // scroll path is exactly the fast-scroll lag ListView was already fixed to avoid.
-        // A brand-new element is only realized when the native list runs out of recyclable
-        // views, so this keeps cleanup off the steady-state scroll path.
+        // Also prune on element realize (matching ListView's
+        // `_getDefaultItemContent`) so a brand-new row triggers a sweep too.
         listViewComponent.cleanup(listView);
         const sl = DocumentNode.createElement('stack-layout');
         listView.appendChild(sl);

--- a/ember-native/src/components/RadListView.gts
+++ b/ember-native/src/components/RadListView.gts
@@ -80,11 +80,19 @@ export default class RadListView<T = any> extends Component<
       listView: NativeElementNode<NativeRadListView>,
     ) {
       this.listView = listView;
-      listView.nativeView.on('itemRecyclingInternal', () => {
-        this.cleanup(listView);
-      });
       const listViewComponent = this;
       function _getDefaultItemContent() {
+        // Prune any window-detached rows only when a new row element is actually being
+        // realized - matching ListView's `_getDefaultItemContent`. Previously `cleanup`
+        // was wired to fire on *every* `itemRecyclingInternal` event, i.e. on every cell
+        // recycle during a scroll, sweeping the whole `elementRefs` map each time (O(n) per
+        // recycle -> O(n^2) per screenful) and, whenever it deleted an entry, bumping the
+        // TrackedMap's `structure` signal - which re-runs the `items` getter's
+        // `keys().map()` and re-diffs the entire `{{#each}}`. That whole-list rebuild on the
+        // scroll path is exactly the fast-scroll lag ListView was already fixed to avoid.
+        // A brand-new element is only realized when the native list runs out of recyclable
+        // views, so this keeps cleanup off the steady-state scroll path.
+        listViewComponent.cleanup(listView);
         const sl = DocumentNode.createElement('stack-layout');
         listView.appendChild(sl);
         Object.defineProperty(sl.nativeView, 'parent', {

--- a/ember-native/src/components/tracked-map.ts
+++ b/ember-native/src/components/tracked-map.ts
@@ -113,4 +113,12 @@ export default class TrackedMap<K, V> {
     this.structure.read();
     return [...this.map.keys()];
   }
+
+  // Untracked entry count. Deliberately does NOT read `structure`, so it can
+  // be used on native (non-tracked) callback paths to cheaply decide whether a
+  // structural change is even necessary, without pulling the caller into
+  // autotracking.
+  get size(): number {
+    return this.map.size;
+  }
 }


### PR DESCRIPTION
## Summary

Reworks `RadListView`'s `elementRefs` cleanup so it stays off the steady-state scroll path (the perf goal) while still pruning window-detached rows when the list actually shrinks (correctness).

## Problem

Originally `cleanup` was wired to fire on *every* `itemRecyclingInternal` event, i.e. on every cell recycle during a scroll:

- It swept the whole `elementRefs` map each time (O(n) per recycle → O(n²) per screenful).
- Whenever it deleted an entry it bumped the `TrackedMap`'s `structure` signal, which re-runs the `items` getter's `keys().map()` and re-diffs the entire `{{#each}}`.

That whole-list rebuild on the scroll path is exactly the fast-scroll lag `ListView` was already fixed to avoid.

An earlier attempt at this PR moved `cleanup` to only run in `_getDefaultItemContent` (element realize). That fixed the perf issue but broke the `RadListView | shows & updates list` test: a list **shrink** recycles rows *without* realizing a new element, so window-detached rows — and their stale text (e.g. `"world"`) — were never pruned. Unlike `ListView`, `RadListView` has no `inRange` template guard, so it relies on `cleanup` to remove out-of-range rows.

## Fix

- Guard `cleanup`: it only performs the O(n) sweep + `structure` bump when there are **more realized rows than `@items.length`** — i.e. the list actually shrank and orphaned rows. During steady-state scroll the realized-row count tracks the visible window and never exceeds `@items.length`, so it's a cheap early-return no-op on the hot path.
- Wire the (now-guarded) `cleanup` to `itemRecyclingInternal` again so a shrink triggers pruning, and also call it from `_getDefaultItemContent` so a realize triggers it too.
- Add an untracked `TrackedMap#size` getter (does **not** read `structure`) so the guard can run on native callback paths without pulling the caller into autotracking.

## Validation

- `pnpm --filter ember-native lint` passes (js, types, hbs).
- `pnpm --filter ember-native build` succeeds.
- Fixes the `test app` CI failure (`RadListView | shows & updates list` — stale `"world"` no longer lingers after the list shrinks to `["hi"]`).