### PR TITLE
Fix FrameElement.onInsertedChild not tracking currentPage

### DIFF
--- a/demo-app/app/tests/unit/frame-element-test.ts
+++ b/demo-app/app/tests/unit/frame-element-test.ts
@@ -1,0 +1,62 @@
+import { setupRenderingTest } from '~/tests/helpers';
+import { createElement } from 'ember-native/dom/element-registry';
+
+// Regression coverage for FrameElement.onInsertedChild not tracking
+// `currentPage` (only `appendChild` did, pre-fix) - see
+// ember-native/src/dom/native/FrameElement.ts. This reproduces the exact
+// "navigate away and back" sequence PageStackOutlet needs (a route's <page>
+// component instance is kept alive and reinserted, rather than destroyed and
+// recreated), which is also the case that most directly exposed the bug:
+// without the fix, re-inserting the very first page after a second page had
+// been shown left the frame silently stuck showing the second page, because
+// `currentPage` still pointed at the first page's own nativeView and the
+// `this.currentPage !== childNode.nativeView` guard in `onInsertedChild`
+// incorrectly compared equal.
+//
+// A real route transition inserts new content via `insertBefore` (with the
+// outgoing page still present as `referenceNode`) before removing the old
+// page - which is exactly what routes `onInsertedChild` through, as opposed
+// to `appendChild`'s own inline navigate() call (only exercised for the very
+// first page ever mounted into a frame). `nativeView.navigate` is stubbed
+// here rather than awaited for real, since the real native transition is an
+// async, Android-animation-driven attach (confirmed via on-device
+// instrumentation - see .pjp-runner/todo.md's todo #525 write-up) that isn't
+// needed to prove this fix: what's under test is FrameElement's own
+// decision of *whether* and *with what* to call `navigate()`, not whether
+// NativeScript's native frame finishes attaching it.
+QUnit.module('FrameElement | Frame.navigate() wiring', function (hooks) {
+  setupRenderingTest(hooks);
+
+  QUnit.test('re-inserting a previously-shown page (navigating back) still navigates the frame to it', function (assert) {
+    const frame = createElement('frame');
+    const page1 = createElement('page');
+    const page2 = createElement('page');
+
+    const navigatedTo: unknown[] = [];
+    frame.nativeView.navigate = ((options: { create: () => unknown }) => {
+      navigatedTo.push(options.create());
+    }) as typeof frame.nativeView.navigate;
+
+    // Initial mount: the very first page a frame ever receives.
+    frame.appendChild(page1);
+    assert.deepEqual(navigatedTo, [page1.nativeView], 'navigates to the first page on initial mount');
+    assert.equal(frame.currentPage, page1.nativeView, 'currentPage tracks the first page');
+
+    // Route transition: the new page is inserted before the outgoing one is removed.
+    frame.insertBefore(page2, page1);
+    assert.deepEqual(navigatedTo, [page1.nativeView, page2.nativeView], 'navigates to the second page on transition');
+    assert.equal(frame.currentPage, page2.nativeView, 'currentPage tracks the second page');
+    frame.removeChild(page1);
+
+    // Navigate back: page1's own component/page instance is reused (kept
+    // alive), so the very same node is reinserted - this is the case the
+    // pre-fix `currentPage` bookkeeping missed entirely.
+    frame.insertBefore(page1, page2);
+    assert.deepEqual(
+      navigatedTo,
+      [page1.nativeView, page2.nativeView, page1.nativeView],
+      'navigates back to the first page instead of silently staying on the second',
+    );
+    assert.equal(frame.currentPage, page1.nativeView, 'currentPage tracks the first page again after navigating back');
+  });
+});

--- a/ember-native/src/dom/native/FrameElement.ts
+++ b/ember-native/src/dom/native/FrameElement.ts
@@ -71,6 +71,7 @@ export default class FrameElement extends NativeElementNode {
       childNode.nativeView instanceof Page &&
       this.currentPage !== childNode.nativeView
     ) {
+      this.currentPage = childNode.nativeView;
       this.nativeView.navigate({
         create: () => childNode.nativeView,
         clearHistory: true,


### PR DESCRIPTION
## Summary
- `FrameElement.appendChild` sets `this.currentPage` before calling `Frame.navigate()`, but `FrameElement.onInsertedChild` - the path every route transition takes after a frame's very first page (Ember replaces `{{outlet}}` content via `insertBefore` with a real reference node, not a null-reference append that falls through to `appendChild`) - never did.
- Left uncorrected, `currentPage` stays pinned to whichever page was inserted first. This has two symptoms, not just one: (a) re-inserting a *different* page node repeatedly looks like a "new" page every time (harmless, just a redundant `navigate()` call), but (b) re-inserting the *same* page node a second time (e.g. navigating back to a route whose `<page>` component instance was kept alive and reused, rather than destroyed/recreated - exactly `PageStackOutlet`'s use case) compares equal to the stale `currentPage` and **silently skips `navigate()` entirely**, leaving the frame stuck showing whatever page came in between. That's a real, user-visible "back navigation does nothing" bug, not just a redundant extra call.
- Fixed by adding the same `this.currentPage = childNode.nativeView;` assignment to `onInsertedChild` that `appendChild` already has.

Found via real on-device (Android emulator CI) instrumentation while investigating todo #525 ("why does `<frame>`'s `Frame.navigate()` wiring never get exercised for content Ember mounts reactively"). That instrumentation also disproved the "`page.frame` is broken for every production route" assumption carried through earlier investigations (#420/#423/#516/#519/#525's own prior write-up): `InspectorSupport`'s real `<frame>{{yield}}</frame>` does correctly attach a page - `page.frame` resolves to a real `Frame` within a tick of the first `navigate()` call on a freshly-mounted frame. See `.pjp-runner/todo.md` for the full trace and a still-open, narrower follow-up (a second, closely-following `navigate()` on the same frame can stall) that's independent of this fix.

## Test plan
- [x] `demo-app/app/tests/unit/frame-element-test.ts`: new regression test exercising page1 -> page2 -> back-to-page1 (same node) directly against `FrameElement`, asserting `navigate()` is called a third time with page1 and `currentPage` tracks it correctly - this is the exact case symptom (b) above covers, and fails without the fix.
- [x] `pnpm exec eslint` clean
- [x] `pnpm build` (glint type-check) passes
- [x] Full `app-test.yml` CI (Android emulator: karma tests incl. the new regression test, + release-boot check) passes with the fix and the new test: https://github.com/ember-native/ember-native/actions/runs/33780528801 (`Executed 15 of 15 SUCCESS`, `Release app started successfully`)
