### PR TITLE
Fix and expand docs-app content

### DIFF
--- a/docs-app/public/docs/1-get-started/index.md
+++ b/docs-app/public/docs/1-get-started/index.md
@@ -1,31 +1,25 @@
 # ember-native
 
-With `ember-native` you can use the power of ember with Nativescript
+With `ember-native` you can use the power of Ember with NativeScript.
 
-some highlights are:
+Some highlights are:
 
-- list view
-- rad list view
-- ember transitions with native animations
-- glint
-- ember inspector
+- `ListView` and `RadListView` components, backed by NativeScript's native,
+  recycling list widgets
+- Router-driven navigation through a real NativeScript `Frame` backstack,
+  including native, animated push/pop transitions
+- Manual (non-router) page stacks, via `PageStack`/`PageStackView`
+- Glint support for templates, including native element tag names
+- Ember Inspector support (element selection/highlighting) in dev builds
 
-create new app by using the template from
-
-https://github.com/ember-native/ember-native-demo
+Get started with the [`ember-native-demo`](https://github.com/ember-native/ember-native-demo)
+template, or see [Setup](./setup) for how an app wires up `ember-native`
+itself.
 
 <Callout>
-  note that currently only v2 addons are supported and they need some custom setup to make services,initializers,routes, templates work.
-  you need to include following code into the app.js. examples are included in the demo app.
-  
-```js
-  context = require.context(
-  '../node_modules/ember-routable-component/dist/_app_',
-  true,
-  /^\.\/.*\.(js|ts|gjs|gts|hbs)$/,
-  'sync'
-);
-context.keys().forEach((key) => (modules[pkgName + key.slice(1).replace(/\.(ts|js|gts|gjs|hbs)$/, '')] = context(key)));
-```
-
+  Only v2 Ember addons are supported natively. Classic (v1) addon compatibility
+  - services, initializers, routes, templates, etc. - is provided by
+  `@embroider/vite`'s `classicEmberSupport()`/`ember()` plugins, the same way
+  it's wired up for any other Embroider + Vite app; see
+  [Setup](./setup) for the full `vite.config.ts`.
 </Callout>

--- a/docs-app/public/docs/1-get-started/setup.md
+++ b/docs-app/public/docs/1-get-started/setup.md
@@ -1,6 +1,145 @@
-# setup a new ember native project
+# Setup a new ember-native project
 
-clone https://github.com/ember-native/ember-native-demo
+The quickest way to start is to clone
+[`ember-native-demo`](https://github.com/ember-native/ember-native-demo),
+which already has everything below wired up. This page documents what that
+template actually does, for adapting an existing app or understanding what's
+going on.
 
-the application route is setup to support ember inspector element selection
-highlighting
+## `vite.config.ts`
+
+An ember-native app needs `@nativescript/vite`'s own config merged together
+with a handful of Ember/Embroider- and ember-native-specific plugins and
+alias fixes. Use `ember-native/utils/nativescript-vite.config.js` rather than
+hand-rolling that merge:
+
+```ts
+// vite.config.ts
+import { createRequire } from "node:module";
+import { defineConfig, mergeConfig } from "vite";
+import { typescriptConfig } from "@nativescript/vite";
+import { hmr } from "ember-vite-hmr";
+import configureNativeScriptVite from "ember-native/utils/nativescript-vite.config.js";
+
+const require = createRequire(import.meta.url);
+
+export default defineConfig(({ mode }) =>
+  configureNativeScriptVite({
+    mode,
+    mergeConfig,
+    typescriptConfig,
+    hmr,
+    require,
+    entry: require.resolve("./boot-app.js"),
+  }),
+);
+```
+
+`mergeConfig`/`typescriptConfig`/`hmr`/`require` are passed through from your
+own imports (rather than re-imported inside the helper) so the exact `vite`
+instance driving your dev server is always the one used. `entry` points at
+whatever file your app's `app/boot.js` should actually run.
+
+Extra options: `vendorExclude` (extra package names to skip in
+`@nativescript/vite`'s HMR vendor-bundle step), `hmrHost` (override the
+Android-emulator HMR host guess for a real device or LAN dev server), `babel`
+(forwarded into the addon's own babel plugin config), `plugins` (extra Vite
+plugins), and `extend` (any other Vite config, merged in last).
+
+## Bootstrapping the app
+
+Three exports from `ember-native` cover the one-time wiring every app needs;
+everything else stays app-specific.
+
+`app/native/setup-ember-native.ts` (imported first, before anything else that
+touches the DOM or Ember):
+
+```ts
+import { setupEmberNativeApp } from "ember-native";
+import { ENV } from "~/config/env";
+
+setupEmberNativeApp(ENV);
+```
+
+`setupEmberNativeApp` installs ember-native's DOM shim, wires up Chrome
+DevTools support in dev builds only, and sets `ENV.rootElement` to the app's
+root native view.
+
+`app/app.js`'s `App` class extends `NativeApplication` instead of
+`@ember/application` directly - it's the same class otherwise, with your own
+`rootElement`/`modulePrefix`/`Resolver`/etc:
+
+```js
+import { NativeApplication } from "ember-native";
+
+export default class App extends NativeApplication {
+  rootElement = ENV.rootElement;
+  autoboot = ENV.autoboot;
+  modulePrefix = ENV.modulePrefix;
+  podModulePrefix = `${ENV.modulePrefix}/pods`;
+  Resolver = Resolver.withModules(compatModules);
+}
+```
+
+`app/native/main.ts` (your NativeScript entry point) creates and registers
+the app instance via `createNativeApplication`:
+
+```ts
+import "./setup-ember-native";
+import "./register-elements"; // your own custom native elements, if any
+import App from "../app";
+import ENV from "~/config/env";
+import { createNativeApplication } from "ember-native";
+
+export default createNativeApplication(App, ENV);
+```
+
+See [Integrate plugin elements](../2-dom/integrate-plugin-elements) for what
+`register-elements.ts` looks like.
+
+## Chrome DevTools support
+
+`setupEmberNativeApp` already wires up Chrome DevTools protocol support for
+you, so most apps don't need to think about this at all. It only matters if
+you have a custom entry point that doesn't go through `setupEmberNativeApp`
+(or you want to trigger inspector support separately, e.g. later than app
+boot) and need to call it yourself - use `maybeSetupInspectorSupport`:
+
+```ts
+import { maybeSetupInspectorSupport } from "ember-native";
+import { ENV } from "~/config/env";
+
+maybeSetupInspectorSupport(ENV);
+```
+
+This is a no-op in release builds, tree-shaken out of the bundle entirely
+rather than merely skipped at runtime - always prefer this helper over
+importing `ember-native/setup-inspector-support` directly, since that
+module's own export is only safe behind this exact dynamic-import pattern.
+
+## The `ember-native-nativescript` binary
+
+This package also installs an `ember-native-nativescript` binary alongside
+the `nativescript` CLI it depends on. It's a thin wrapper that forwards all
+arguments unchanged to `nativescript`/`tns`, but works around a bug where
+`nativescript build`/`nativescript test` never copy `@nativescript/vite`'s
+build output into the native platform project, silently producing an empty
+or stale native app (only `nativescript debug`'s watch-mode path copies it
+correctly). If your app uses `@nativescript/vite`, point your `package.json`
+scripts at `ember-native-nativescript` instead of `nativescript`/`tns`
+directly:
+
+```json
+{
+  "scripts": {
+    "run": "ember-native-nativescript debug android",
+    "test": "ember-native-nativescript test android --no-watch",
+    "build": "ember-native-nativescript build android",
+    "debug": "ember-native-nativescript debug android --debug-brk",
+    "prepare-android": "ember-native-nativescript prepare android"
+  }
+}
+```
+
+Run it from your app's project root (the directory that depends on
+`nativescript`), the same place you'd run `nativescript` from.

--- a/docs-app/public/docs/2-dom/integrate-plugin-elements.md
+++ b/docs-app/public/docs/2-dom/integrate-plugin-elements.md
@@ -16,15 +16,22 @@ registerNativeElement("RadSideDrawer", () => RadSideDrawer);
 notice that the registration uses the camel case name.
 but in the templates you will have to use the dash form.
 
-2. setup support for glint in globals.d.ts
+2. setup support for glint by augmenting `NativeElementsTagNameMap`
 
-```js
-type ViewBase = import('@nativescript/core').ViewBase;
-type NativeElementNode<T extends ViewBase> =
-  import('../dom/native/NativeElementNode').default<T>;
+Glint resolves a template's native element tags through the
+`NativeElementsTagNameMap` interface (`ember-native/dom/native-elements-tag-name-map`),
+not the DOM's own `HTMLElementTagNameMap` - add your plugin's tags to it via
+declaration merging, in a `.d.ts` file included by your app (e.g. `types/globals.d.ts`):
 
-interface HTMLElementTagNameMap {
-  'rad-list-view': NativeElementNode<import('nativescript-ui-listview').RadListView>;
-  'rad-side-drawer': NativeElementNode<import('nativescript-ui-sidedrawer').RadSideDrawer>;
+```ts
+import type NativeElementNode from "ember-native/dom/native/NativeElementNode";
+
+declare module "ember-native/dom/native-elements-tag-name-map" {
+  interface NativeElementsTagNameMap {
+    "rad-side-drawer": NativeElementNode<import("nativescript-ui-sidedrawer").RadSideDrawer>;
+  }
 }
 ```
+
+`rad-list-view` doesn't need this step - it's already declared by
+`ember-native` itself.

--- a/docs-app/public/docs/3-glint/index.md
+++ b/docs-app/public/docs/3-glint/index.md
@@ -5,13 +5,16 @@ Glint is supported, you just need to import
 - `import ember-native/types/glint`
 - `import ember-native/types/globals`
 
-to support elements coming from other plugins you need to register them
+to support elements coming from other plugins you need to register them - see
+[Integrate plugin elements](../2-dom/integrate-plugin-elements) for the full
+runtime registration + Glint type augmentation steps:
 
 ```ts
-type ViewBase = import("@nativescript/core").ViewBase;
-type NativeElementNode<T extends ViewBase> = import("../dom/native/NativeElementNode").default<T>;
-interface HTMLElementTagNameMap {
-  "rad-list-view": NativeElementNode<import("nativescript-ui-listview").RadListView>;
-  "rad-side-drawer": NativeElementNode<import("nativescript-ui-sidedrawer").RadSideDrawer>;
+import type NativeElementNode from "ember-native/dom/native/NativeElementNode";
+
+declare module "ember-native/dom/native-elements-tag-name-map" {
+  interface NativeElementsTagNameMap {
+    "rad-side-drawer": NativeElementNode<import("nativescript-ui-sidedrawer").RadSideDrawer>;
+  }
 }
 ```

--- a/docs-app/public/docs/4-router-transitions/frame-outlet.md
+++ b/docs-app/public/docs/4-router-transitions/frame-outlet.md
@@ -1,0 +1,103 @@
+# Sub-routes and back navigation
+
+## Why a bare `{{outlet}}` doesn't work here
+
+Ember never tears down a route's rendered output while any of its child
+routes are active - the parent route's own component simply isn't destroyed
+by entering a child route. A `<page>` can only ever be a direct child of a
+`<frame>` though, so a bare `{{outlet}}` placed _inside_ a route's own
+`<page>` would nest a child route's `<page>` inside it instead, which
+NativeScript rejects at runtime with `Page can only be nested inside Frame`.
+
+`FrameOutlet` (`ember-native/components`) renders its block (the route's own
+`<page>`) and `{{outlet}}` (a child route's `<page>`, if one is active) as
+siblings instead, so both land as direct children of the enclosing `<frame>`,
+in route-depth order:
+
+```gts
+// routes/list-view.gts
+import { FrameOutlet } from "ember-native/components";
+
+class Page extends Component {
+  <template>
+    <FrameOutlet>
+      <page id="list-view-page">
+        {{! ...the list-view route's own content... }}
+      </page>
+    </FrameOutlet>
+  </template>
+}
+```
+
+```gts
+// routes/list-view/item.gts - a child route of `list-view` above
+class Page extends Component {
+  <template>
+    <page id="item-page">
+      {{! ...the item detail route's own content, including its own back
+           button wired to the `history` service (see below)... }}
+    </page>
+  </template>
+}
+```
+
+Neither page needs any visibility handling of its own - navigating into
+`list-view.item` pushes `item-page` onto the real backstack (animated by
+whatever transition [`NativeRouter#transitionTo`](./) staged); navigating
+back pops it and shows the exact same `list-view-page` instance, laid out
+exactly as NativeScript left it. This composes for arbitrarily deep nesting:
+if `list-view.item` itself wraps its own content in another `FrameOutlet`, a
+further child route stacks on top of it the same way.
+
+## Navigating back, via `history`
+
+`HistoryService` (`ember-native/history`) pairs with `native-router` to make
+back navigation symmetrical with the transition you pushed forward with - it
+pops its own stack of visited URLs and replays whichever `backTransition` was
+staged for the current entry, so a route generally only needs to call
+`nativeRouter.transitionTo(...)` on the way in and `history.back()` on the
+way out:
+
+```gts
+import { on } from "@ember/modifier";
+import { service } from "@ember/service";
+import Component from "@glimmer/component";
+import type HistoryService from "ember-native/services/history";
+
+class Page extends Component {
+  @service("ember-native/history") history!: HistoryService;
+
+  <template>
+    <page id="item-page">
+      <action-bar title="Item">
+        <navigation-button
+          {{on "tap" this.history.back}}
+          visibility="{{if this.history.stack.length 'visible' 'collapse'}}"
+          android.position="left"
+          text="Go back"
+          android.systemIcon="ic_menu_back"
+        />
+      </action-bar>
+      {{! ... }}
+    </page>
+  </template>
+}
+```
+
+`history.stack.length` is a convenient guard for hiding the back button on
+whichever page has nothing to go back to.
+
+`HistoryService` also handles Android's hardware back key and iOS's edge
+swipe-back gesture, keeping Ember's router (and its own stack) in sync with
+whatever native navigation the platform already did - you don't need to wire
+either of those up yourself.
+
+## A caveat: querying by tag name across a stack
+
+Once more than one page has been pushed, `document`/element lookups that
+search the whole tree by tag (e.g. `document.getElementByTagName("action-bar")`)
+can match a backstacked page's element instead of the currently-shown one: a
+backstacked `<page>` stays a real child of `<frame>` even though NativeScript
+isn't currently displaying it. Prefer `getElementById` scoped to a known page
+(give each stacked `<page>` a distinct `id`, as above) over a blanket tag
+search.

--- a/docs-app/public/docs/4-router-transitions/index.md
+++ b/docs-app/public/docs/4-router-transitions/index.md
@@ -1,25 +1,46 @@
 # Router Transitions
 
-to use the native transitions you have to use the `native-router` service.
-
-e.g.
+Routes render under a real NativeScript `Frame`, so navigating between them
+can play the same native, animated push/pop transitions any (non-Ember)
+NativeScript app can. To trigger one, use the `native-router` service instead
+of `@ember/routing/route-info`/the router service directly:
 
 ```js
 import Component from "@glimmer/component";
+import { service } from "@ember/service";
 
 export default class Page extends Component {
   @service("ember-native/native-router") nativeRouter;
 
   goto() {
-    this.nativeRouter.transitionTo("route-name", model || null, {
+    this.nativeRouter.transitionTo("route-name", model || null, queryParams, {
       transition: myTransition,
-      animated: true || false,
+      animated: true,
     });
   }
 }
 ```
 
-where my transition has the following interface:
+`transitionTo(name, model, queryParams, transition, backTransition)` sets the
+given `transition` just before calling the normal Ember `Router#transitionTo`.
+It's picked up the next time a `<page>` is pushed for this route change and
+passed straight to NativeScript's `Frame#navigate()`, which plays the
+animation. The optional `backTransition` is what plays when navigating back
+_out_ of the destination instead (replayed by the `history` service's
+`back()`), letting a push and its corresponding pop use different
+transitions:
+
+```js
+this.nativeRouter.transitionTo(
+  "route-name",
+  model,
+  undefined,
+  { transition: { name: "slide", direction: "left" }, animated: true },
+  { transition: { name: "slide", direction: "right" }, animated: true },
+);
+```
+
+`transition`/`backTransition` are each `{ transition: NavigationTransition, animated: boolean }`, where `NavigationTransition` is:
 
 ```ts
 // copied from nativescript source
@@ -59,3 +80,10 @@ interface NavigationTransition {
   curve?: any;
 }
 ```
+
+See [Sub-routes and back navigation](./frame-outlet) for how child routes
+stack on top of a parent route without re-rendering it, and how back
+navigation (hardware back button, iOS edge-swipe) stays in sync with Ember's
+router. For navigation that isn't router-driven at all (a wizard,
+master/detail inside a single route), see
+[Manual stacks, via `PageStack`/`PageStackView`](./page-stack) instead.

--- a/docs-app/public/docs/4-router-transitions/page-stack.md
+++ b/docs-app/public/docs/4-router-transitions/page-stack.md
@@ -1,0 +1,107 @@
+# Manual stacks, via `PageStack`/`PageStackView`
+
+For navigation that isn't router-driven (e.g. a wizard, or master/detail
+inside a single route), use the `PageStack` class directly instead of the
+router: it's a small tracked stack of entries that, once pushed, stay mounted
+until explicitly evicted - only `activeKey` changes when navigating back and
+forth. Unlike [router-driven navigation](./frame-outlet), it's not backed by
+a real `Frame` backstack, so it toggles `visibility` between entries instead.
+
+`PageStackView` renders one for you, invoking each pushed entry with an
+`@isActive` boolean rather than wrapping it in a container of its own to
+toggle - a `<page>` can only be a direct child of a `<frame>` (or the app's
+own root), so wrapping one to toggle its visibility would crash at runtime
+with `Page can only be nested inside Frame`; apply `@isActive` as the
+`visibility` of your own root element directly instead:
+
+```gts
+import { PageStackView } from "ember-native/components";
+import PageStack from "ember-native/page-stack";
+import { on } from "@ember/modifier";
+import { fn } from "@ember/helper";
+import StepOne from "./step-one";
+
+class Wizard extends Component {
+  stack = new PageStack();
+  push = (content, key) => this.stack.push(content, key);
+  back = () => this.stack.pop();
+
+  <template>
+    <PageStackView @stack={{this.stack}} />
+    <button {{on "tap" (fn this.push StepOne "step-one")}}>Start</button>
+  </template>
+}
+```
+
+```gts
+// step-one.gts - a pushed component that uses `@isActive` needs it declared
+// in its own Args signature, and applies it to its own root element's
+// `visibility`. A pushed component that ignores `@isActive` entirely (e.g.
+// static content with nothing to hide) doesn't need either.
+interface StepOneSignature {
+  Args: { isActive: boolean };
+}
+
+class StepOne extends Component<StepOneSignature> {
+  <template>
+    <stack-layout visibility={{if @isActive "visible" "collapse"}}>
+      {{! ...this step's own content... }}
+    </stack-layout>
+  </template>
+}
+```
+
+An entry's `content` is anything invokable as a component - a bare component
+class (as pushed above, with no args), or, for a step that needs args bound
+in, a curried component built with the `{{component}}` template helper at
+the call site, e.g. from `StepOne`'s own template (`@push` passed down from
+`Wizard` above):
+
+```gts
+<button {{on "tap" (fn @push (component StepTwo onDone=@onDone) "step-two")}}>
+  Next
+</button>
+```
+
+`PageStackView` renders `<entry.content @isActive={{...}} />` for every entry
+ever pushed, `@isActive` true only for the one whose `key` matches
+`stack.activeKey`. `pop()` reactivates the previous entry without destroying
+either one; `evict(key)` removes an entry for good, so pushing it again later
+renders it fresh.
+
+The same tag-name-lookup caveat from
+[Sub-routes and back navigation](./frame-outlet#a-caveat-querying-by-tag-name-across-a-stack)
+applies here too, for the same underlying reason: every pushed entry stays
+mounted, just not all `visible`.
+
+## Animating the transition, via `pageTransition`
+
+Toggling `visibility` directly (as above) swaps pages instantly - there's no
+equivalent of `Frame`'s animated push/pop transitions. The `pageTransition`
+modifier (`ember-native/modifiers`) gets you the closest approximation
+available without touching a `<frame>`'s own navigation/backstack: apply it
+in place of the `visibility` binding, on the same element:
+
+```gts
+import { pageTransition } from "ember-native/modifiers";
+
+<stack-layout {{pageTransition @isActive}}>
+```
+
+Its one positional argument is whether the page should be active/visible,
+same sense as `PageStackView`'s `@isActive`. Becoming active fades the page
+in from transparent (`opacity` `0` -> `1` over an optional `duration` in ms,
+default `200`); becoming inactive collapses it immediately, with no
+fade-out. That asymmetry isn't an oversight: fading the outgoing page out too
+would require briefly leaving two pages `visible` at once so they can
+cross-fade, which a `stack-layout` root can't lay out side by side without
+squeezing each into half the space.
+
+Because the fade-in is a real native animation, its completion isn't tracked
+by Ember's run loop - `await settled()` (or `click()`/`visit()`, which call
+it internally) resolves as soon as the _reactive_ state (routing,
+`visibility`) has settled, not once `opacity` has finished animating to `1`.
+Assertions against `visibility`/other attributes are unaffected (they're set
+synchronously, before the animation starts); if a test needs to assert
+against `opacity` itself, poll for the end state instead of assuming
+`settled()` covers it.

--- a/docs-app/public/docs/5-components/index.md
+++ b/docs-app/public/docs/5-components/index.md
@@ -1,4 +1,18 @@
 # Ember Components
 
-this components wrap the native elements to provide necessary bindings
-and functionality
+These components (`ember-native/components`) wrap native elements or native
+navigation primitives to provide the bindings and functionality plain
+templates can't express on their own:
+
+- [`ListView`](./list-view-component) - a virtualized, native `ListView`
+- [`RadListView`](./rad-list-view-component) - `nativescript-ui-listview`'s
+  `RadListView`, with header/footer blocks
+- `FrameOutlet` - lets a child route's `<page>` stack on top of a parent
+  route's, without re-rendering the parent - see
+  [Sub-routes and back navigation](../4-router-transitions/frame-outlet)
+- `PageStackView` - renders a `PageStack` for non-router-driven navigation -
+  see [Manual stacks](../4-router-transitions/page-stack)
+- `InspectorSupport` - wraps a route tree in the `<frame>` that both
+  router-driven navigation and Ember Inspector element selection need; wrap
+  your application route/template's `{{outlet}}` in it once
+  (`<InspectorSupport>{{outlet}}</InspectorSupport>`)

--- a/docs-app/public/docs/5-components/list-view-component.md
+++ b/docs-app/public/docs/5-components/list-view-component.md
@@ -25,6 +25,7 @@ import { on } from "@ember/modifier";
 import { service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import Component from "@glimmer/component";
+import RoutableComponentRoute from "ember-routable-component";
 import type HistoryService from "ember-native/services/history";
 
 class Page extends Component {
@@ -69,10 +70,10 @@ class Page extends Component {
   </template>
 }
 
-export default Page;
+export default class IndexRoute extends RoutableComponentRoute(Page) {}
 ```
 
-See [Setup](../1-get-started/setup) for how a `<page>`-rooted component like
-this one gets exported as an actual `Route`, and
+See [Testing page-rooted components](../6-testing) for how a `<page>`-rooted
+component like this one gets exported as an actual `Route`, and
 [Sub-routes and back navigation](../4-router-transitions/frame-outlet) for
 `history`/navigating to a nested route.

--- a/docs-app/public/docs/5-components/list-view-component.md
+++ b/docs-app/public/docs/5-components/list-view-component.md
@@ -2,8 +2,9 @@
 
 ```gts
 import { ListView } from "ember-native/components";
+
 <template>
-  <ListView @items={{this.list}}>
+  <ListView height="100%" @items={{this.list}}>
     <:item as |item|>
       <label>
         {{item}}
@@ -13,60 +14,65 @@ import { ListView } from "ember-native/components";
 </template>
 ```
 
+`@items` accepts any array; give the `ListView` an explicit `height` (as
+above) - without one, NativeScript never lays out/realizes any rows.
+
+A fuller example, as a route's page:
+
 ```gts
-import { RadListView } from "ember-native/components";
-import RoutableComponentRoute from "ember-routable-component";
-import { LinkTo } from "ember-ative/components";
+import { ListView } from "ember-native/components";
 import { on } from "@ember/modifier";
 import { service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import Component from "@glimmer/component";
+import type HistoryService from "ember-native/services/history";
+
 class Page extends Component {
-  @service history;
+  @service("ember-native/history") history!: HistoryService;
   @tracked list = ["a", "b", "c"];
-  start = () => {
+
+  constructor(...args: ConstructorParameters<typeof Component>) {
+    super(...args);
     const lists = [
       ["a", "b", "c"],
       ["a", "b", "c", "d", "e"],
       ["1", "2", "3"],
-      ["1", "2", "3", 4, 5],
+      ["1", "2", "3", "4", "5"],
     ];
     setInterval(() => {
       this.list = lists[Math.floor(Math.random() * lists.length)];
     }, 200);
-  };
+  }
+
   <template>
     <page>
-      <actionBar title="MyApp">
-        <navigationButton
+      <action-bar title="MyApp">
+        <navigation-button
           {{on "tap" this.history.back}}
-          visibility="{{unless this.history.stack.length 'collapse'}}"
+          visibility="{{if this.history.stack.length 'visible' 'collapse'}}"
           android.position="left"
           text="Go back"
           android.systemIcon="ic_menu_back"
         />
-      </actionBar>
-      <stackLayout>
-        <label text="Hello world 2!"></label>
-        <LinkTo @route="test" @text="test" />
-        {{(this.start)}}
-        <ListView @items={{this.list}}>
+      </action-bar>
+      <stack-layout>
+        <label text="Hello world!"></label>
+        <ListView height="100%" @items={{this.list}}>
           <:item as |item|>
             <label>
               {{item}}
             </label>
           </:item>
         </ListView>
-      </stackLayout>
+      </stack-layout>
     </page>
   </template>
 }
 
-// this will generate a Route class and use the provided template
-export default class IndexRoute extends RoutableComponentRoute(Page) {
-  activate() {
-    console.log("activate");
-  }
-}
-``;
+export default Page;
 ```
+
+See [Setup](../1-get-started/setup) for how a `<page>`-rooted component like
+this one gets exported as an actual `Route`, and
+[Sub-routes and back navigation](../4-router-transitions/frame-outlet) for
+`history`/navigating to a nested route.

--- a/docs-app/public/docs/5-components/rad-list-view-component.md
+++ b/docs-app/public/docs/5-components/rad-list-view-component.md
@@ -27,6 +27,7 @@ import { on } from "@ember/modifier";
 import { service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import Component from "@glimmer/component";
+import RoutableComponentRoute from "ember-routable-component";
 import type HistoryService from "ember-native/services/history";
 
 class Page extends Component {
@@ -73,7 +74,7 @@ class Page extends Component {
   </template>
 }
 
-export default Page;
+export default class IndexRoute extends RoutableComponentRoute(Page) {}
 ```
 
 `RadListView` isn't registered as a native element by default - register it

--- a/docs-app/public/docs/5-components/rad-list-view-component.md
+++ b/docs-app/public/docs/5-components/rad-list-view-component.md
@@ -1,11 +1,13 @@
 # Rad List View Component
 
-an extract how in it can be used
+Wraps `nativescript-ui-listview`'s `RadListView`, adding optional header and
+footer blocks:
 
 ```gts
 import { RadListView } from "ember-native/components";
+
 <template>
-  <RadListView @items={{this.list}}>
+  <RadListView height="100%" @items={{this.list}}>
     <:header><label>header</label></:header>
     <:item as |item|>
       <label>
@@ -17,46 +19,47 @@ import { RadListView } from "ember-native/components";
 </template>
 ```
 
-full example
+A fuller example, as a route's page:
 
 ```gts
-import { ListView } from "ember-native/components";
-import RoutableComponentRoute from "ember-routable-component";
-import { LinkTo } from "ember-ative/components";
+import { RadListView } from "ember-native/components";
 import { on } from "@ember/modifier";
 import { service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import Component from "@glimmer/component";
+import type HistoryService from "ember-native/services/history";
+
 class Page extends Component {
-  @service history;
+  @service("ember-native/history") history!: HistoryService;
   @tracked list = ["a", "b", "c"];
-  start = () => {
+
+  constructor(...args: ConstructorParameters<typeof Component>) {
+    super(...args);
     const lists = [
       ["a", "b", "c"],
       ["a", "b", "c", "d", "e"],
       ["1", "2", "3"],
-      ["1", "2", "3", 4, 5],
+      ["1", "2", "3", "4", "5"],
     ];
     setInterval(() => {
       this.list = lists[Math.floor(Math.random() * lists.length)];
     }, 200);
-  };
+  }
+
   <template>
     <page>
-      <actionBar title="MyApp">
-        <navigationButton
+      <action-bar title="MyApp">
+        <navigation-button
           {{on "tap" this.history.back}}
-          visibility="{{unless this.history.stack.length 'collapse'}}"
+          visibility="{{if this.history.stack.length 'visible' 'collapse'}}"
           android.position="left"
           text="Go back"
           android.systemIcon="ic_menu_back"
         />
-      </actionBar>
-      <stackLayout>
-        <label text="Hello world 2!"></label>
-        <LinkTo @route="test" @text="test" />
-        {{(this.start)}}
-        <RadListView @items={{this.list}}>
+      </action-bar>
+      <stack-layout>
+        <label text="Hello world!"></label>
+        <RadListView height="100%" @items={{this.list}}>
           <:header><label>header</label></:header>
           <:item as |item|>
             <label>
@@ -65,16 +68,13 @@ class Page extends Component {
           </:item>
           <:footer><label>footer</label></:footer>
         </RadListView>
-      </stackLayout>
+      </stack-layout>
     </page>
   </template>
 }
 
-// this will generate a Route class and use the provided template
-export default class IndexRoute extends RoutableComponentRoute(Page) {
-  activate() {
-    console.log("activate");
-  }
-}
-``;
+export default Page;
 ```
+
+`RadListView` isn't registered as a native element by default - register it
+yourself first, see [Integrate plugin elements](../2-dom/integrate-plugin-elements).

--- a/docs-app/public/docs/6-testing/index.md
+++ b/docs-app/public/docs/6-testing/index.md
@@ -1,0 +1,98 @@
+# Testing page-rooted components
+
+A NativeScript `Page` only gets a working `.frame` (and, by extension, a
+working `<action-bar>`) when it is a direct native child of a `<frame>`
+element. Every top-level route/screen component in an ember-native app
+renders a `<page>`, but `setupRenderingTest` from `ember-qunit` never
+provides a `<frame>` ancestor - rendering such a component directly crashes
+with `TypeError: page.frame._getNavBarVisible is not a function` the moment
+its `<action-bar>` loads.
+
+Glimmer templates are compiled statically, so a component's real template
+can't be introspected or have its `<page>` wrapper stripped at runtime.
+Instead, use `withTemplateForTest` (from
+`ember-native/test-support/with-template-for-testing`) to render a test-only
+double of the component with a substitute template - the same content minus
+the `<page>`/`<action-bar>` wrapper - while keeping the original class's
+services, args, and lifecycle intact.
+
+`withTemplateForTest` takes a component class, so a route module needs to
+export the `<page>`-rooted component itself, not just the generated `Route`:
+
+```gts
+// my-app/routes/index.gts
+import RoutableComponentRoute from "ember-routable-component";
+import Component from "@glimmer/component";
+
+export class Page extends Component {
+  <template>
+    <page>
+      <action-bar title="Ember Nativescript Examples"></action-bar>
+      <stack-layout>
+        {{! ... }}
+      </stack-layout>
+    </page>
+  </template>
+}
+
+export default class IndexRoute extends RoutableComponentRoute(Page) {}
+```
+
+```gts
+import { setupRenderingTest } from "my-app/tests/helpers";
+import { render } from "@ember/test-helpers";
+import { withTemplateForTest } from "ember-native/test-support/with-template-for-testing";
+import { Page as IndexPage } from "my-app/routes/index";
+
+QUnit.module("Integration | Component | index page", function (hooks) {
+  setupRenderingTest(hooks);
+
+  QUnit.test("renders the list of examples", async function (assert) {
+    const TestableIndexPage = withTemplateForTest(
+      IndexPage,
+      <template>
+        <stack-layout>
+          {{! ...same content as IndexPage's template, minus <page>/<action-bar> }}
+        </stack-layout>
+      </template>,
+    );
+
+    await render(<template><TestableIndexPage /></template>);
+    assert.dom(this.element).containsText("List View");
+  });
+});
+```
+
+This only exercises the component's non-`<page>` content - it can't verify
+`<action-bar>` rendering or real navigation-frame behavior. Test those
+end-to-end instead, via `setupApplicationTest` + `visit()`, which boots the
+real app and its native `Application`.
+
+## Reading text content in tests
+
+`ViewNode#textContent` reads each leaf element's current `text`/`html`
+directly from the underlying native view - there is no microtask, native
+layout pass, or debounced write between a `text={{...}}` binding (or a child
+text-node update) and the value `textContent` reads. So `await
+click(...)`/`await rerender()` (which just await `settled()`) are always
+enough - `.textContent` never needs a workaround after a tap or other
+interaction.
+
+A few things can still make `.textContent` look wrong if you're not
+expecting them, none of which is a staleness bug:
+
+- Leaf contents are joined with a single space and empty/falsy segments are
+  dropped, so e.g. `<button>counter: {{state.counter}}</button>` reads back
+  as `'counter:  0'` (two spaces - `'counter: '` and `'0'` are separate text
+  nodes) rather than `'counter: 0'`.
+- Whitespace _between_ elements in a template is itself a real, non-empty
+  text node and gets counted the same way: `<button>a</button>` and
+  `<label ... />` written on separate, indented lines read back with that
+  literal newline/indentation between them (e.g. `'a \n  b'`). Put sibling
+  elements on one line, with no whitespace between them, when asserting on
+  their combined `textContent`.
+- Reading an attribute off an element whose native view isn't currently set
+  (e.g. mid-teardown, or a `ListView`/`RadListView` row between native
+  recycle callbacks) silently contributes nothing rather than throwing, so a
+  query that happens to hit such an element mid-teardown reads back a
+  shorter string, not necessarily an outright empty one.


### PR DESCRIPTION
## Summary
- Fixed docs-app pages that had drifted from the real, current library API: broken example code (an `ember-ative` typo, an invalid closing fence), a Glint plugin-registration example that augmented the wrong interface (`HTMLElementTagNameMap` instead of `NativeElementsTagNameMap` - it silently did nothing), a stale pre-Vite `require.context` bootstrapping snippet, and a wrong `native-router#transitionTo()` signature.
- Expanded coverage to match what `ember-native/README.md` already documents but `docs-app` didn't: full app bootstrapping/setup (vite config, `setupEmberNativeApp`, `ember-native-nativescript` binary), sub-route navigation via `FrameOutlet`, manual `PageStack`/`PageStackView`, and testing page-rooted components (`withTemplateForTest`, `textContent` gotchas).
- Every code sample and API claim was checked against the actual source (`ember-native/src/**`, `demo-app/**`) rather than copied from the old docs, including catching one wrong claim in an earlier draft (`InspectorSupport` is not auto-wired by `setupEmberNativeApp` - it has to be added to the app's own application route).

## Test plan
- [x] `pnpm build` (docs-app, production mode) succeeds and picks up all new/changed pages under `dist/docs/`
- [x] `pnpm exec prettier -c public/docs` passes
- [ ] `pnpm test` (real QUnit + a11y audit run via headless Chrome) - not runnable in this environment (no Chrome binary available); should be verified by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)