### PR TITLE
Seed ancestor pages into the Frame backstack on cross-tree jumps into a nested route

### DIFF
--- a/demo-app/app/tests/integration/list-view-stack-test.ts
+++ b/demo-app/app/tests/integration/list-view-stack-test.ts
@@ -109,4 +109,69 @@ QUnit.module('Acceptance | list-view page stack', function (hooks) {
       );
     }
   );
+
+  QUnit.test(
+    'a cross-tree jump straight into a nested route seeds the ancestor into the backstack in a single transition',
+    async function (assert) {
+      // `index` is an unrelated top-level route - `list-view` (the parent of
+      // the route we're about to jump into) is never visited on its own, so
+      // `FrameElement.reconcile()` sees a common-prefix-zero jump into a
+      // 2-deep desired stack (`list-view` + `list-view.item`) - the case
+      // `seedBackstack` exists for (see `FrameElement.ts`).
+      await visit('/');
+      const frame: Frame = ENV.rootElement.getElementByTagName('frame').nativeView;
+      await waitUntil(() => !!frame.currentPage, { timeout: 5000 });
+      assert.false(frame.canGoBack(), 'nothing to go back to yet');
+
+      await visit('/list-view/a');
+
+      const listPage = ENV.rootElement.getElementById('list-view-page');
+      const listPageNativeView: Page = listPage?.nativeView;
+      const itemPage = ENV.rootElement.getElementById('item-page');
+      const itemPageNativeView: Page = itemPage?.nativeView;
+
+      await waitUntil(() => frame.currentPage === itemPageNativeView, { timeout: 5000 });
+
+      assert.true(
+        frame.canGoBack(),
+        'the list page landed on the real Frame backstack even though it was never its own transition'
+      );
+      assert.equal(
+        frame.backStack.length,
+        1,
+        'exactly one backstack entry - the seeded list page, not the index page or two entries'
+      );
+      assert.true(
+        frame.backStack[0]?.resolvedPage === listPageNativeView,
+        'the seeded backstack entry is the same list-view Page instance Ember rendered'
+      );
+
+      // The discriminating check: a `BackstackEntry` `seedBackstack` spliced
+      // in never went through its own `navigate()`/fragment transaction -
+      // going back to it is what actually proves the lazily-created
+      // fragment/view-controller renders on a real device, not just that
+      // the JS-level `backStack` array looks right.
+      //
+      // Not `history.back()`: `HistoryService`'s stack recorded a single
+      // entry for the whole `/` -> `/list-view/a` jump (one router
+      // transition, however many nested levels it spans), so `back()` would
+      // undo the entire jump and land on `/` again, skipping the seeded
+      // `list-view` entry entirely. Visiting `/list-view` directly instead
+      // is the single in-tree step from `list-view.item` back to its parent
+      // - exactly the case `FrameElement.reconcile()` resolves with a real
+      // `goBack()` to the seeded backstack entry (`i !== 0` in
+      // `reconcile()`, not another cross-tree replace).
+      await visit('/list-view');
+      await waitUntil(() => frame.currentPage === listPageNativeView, { timeout: 5000 });
+
+      assert.true(
+        !!listPage?.getElementByTagName('actionbar')?.getAttribute('title')?.includes('List View'),
+        'going back from the seeded jump renders the real list-view page, not a blank/broken fragment'
+      );
+      assert.false(
+        frame.canGoBack(),
+        'the backstack is empty again after going back to the seeded root'
+      );
+    }
+  );
 });

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -295,6 +295,33 @@ computing a fixed list of steps up front, means it self-heals even if Ember
 makes several changes before the frame catches up (e.g. a fast
 forward-then-back collapses to a no-op once the drain finishes).
 
+### Cross-tree jumps into a nested route
+
+Diffing against the frame's actual stack usually finds a non-empty common
+prefix (in-tree navigation only ever changes the last level or two), but a
+jump to an unrelated route tree - e.g. reaching a nested `list-view.item`
+straight from an unrelated top-level route, never having visited `list-view`
+itself - has nothing in common with what the frame currently shows. Naively,
+reconciling that would still take one step per level: push `list-view`,
+settle, push `list-view.item`, settle - materializing and briefly displaying
+the parent page's own transition/animation on the way to a destination that
+was never `list-view` itself.
+
+On Android, `reconcile()` avoids this: it does a single `navigate()` straight
+to the true leaf (`list-view.item`), then splices plain `BackstackEntry`
+objects for the intermediate ancestors (`list-view`) directly into the
+frame's backstack once that transition settles, instead of running each
+ancestor through its own `navigate()`. `Frame._goBackCore` already tolerates
+a backstack entry with no native fragment - it creates one on demand (the
+same path used to recreate a fragment the OS discarded after the activity
+was destroyed) - so a `goBack()`/`HistoryService#back()` into a seeded
+ancestor still lands on a real, correctly-rendered page, confirmed on-device
+via `demo-app/app/tests/integration/list-view-stack-test.ts`'s cross-tree
+jump test. This is Android-only: iOS's `popToViewControllerAnimated` can
+only pop to a view controller that was actually pushed, so a synthetic entry
+there would be an unreachable target - iOS still steps through each
+ancestor.
+
 One consequence of this design: a page is only ever pushed with a *fresh*
 `Page` instance (whatever Ember just created) - going back always uses
 `goBack()`, resuming the frame's own preserved backstack entry, never a

--- a/ember-native/src/dom/native/FrameElement.ts
+++ b/ember-native/src/dom/native/FrameElement.ts
@@ -1,10 +1,14 @@
 import { Frame } from '@nativescript/core/ui/frame';
 import type { NavigationTransition, View } from '@nativescript/core';
+import { isAndroid } from '@nativescript/core/platform';
+import type { BackstackEntry } from '@nativescript/core/ui/frame/frame-interfaces';
 
 import { createElement } from '../element-registry.ts';
 import ViewNode from '../nodes/ViewNode.ts';
 import NativeElementNode from './NativeElementNode.ts';
 import { Page } from '@nativescript/core/ui/page';
+
+let syntheticBackstackTagCounter = 0;
 
 let nextTransition: {
   transition: NavigationTransition | undefined;
@@ -70,6 +74,11 @@ export default class FrameElement extends NativeElementNode {
   private reconcileScheduled = false;
   private reconciling = false;
   private pendingTransition: typeof nextTransition = null;
+  // Set right before a cross-tree jump's single `navigate()` call settles -
+  // see the `i === 0` branch in `reconcile()` and `seedBackstack()` below.
+  // Holds the ancestor pages (outermost first) that still need a real
+  // backstack entry even though they never got their own transition.
+  private pendingBackstackSeed: Page[] | null = null;
 
   constructor() {
     super('frame', Frame, null);
@@ -85,6 +94,10 @@ export default class FrameElement extends NativeElementNode {
         return;
       }
       this.reconciling = false;
+      if (this.pendingBackstackSeed) {
+        this.seedBackstack(this.pendingBackstackSeed);
+        this.pendingBackstackSeed = null;
+      }
       this.reconcile();
     });
   }
@@ -237,8 +250,22 @@ export default class FrameElement extends NativeElementNode {
       // top-level route in one go) - there's nothing to go back *to* in
       // that case, so replace the stack's base outright instead.
       if (i === 0) {
+        // Cross-tree jump straight into a nested route (`desired.length > 1`):
+        // on Android, do a single native transition straight to the true
+        // leaf and splice synthetic `BackstackEntry` objects for the
+        // intermediate ancestors into the backstack once it settles (see
+        // `seedBackstack`), instead of materializing each ancestor with its
+        // own transition first. iOS's `popToViewControllerAnimated` can only
+        // pop to a view controller that was actually pushed, so a synthetic
+        // entry there would be an unreachable `goBack()`/edge-swipe target -
+        // iOS keeps stepping through each ancestor instead.
+        const seedAncestors = isAndroid && desired.length > 1;
+        if (seedAncestors) {
+          this.pendingBackstackSeed = desired.slice(0, -1);
+        }
+        const leaf = seedAncestors ? desired[desired.length - 1]! : desired[0]!;
         this.nativeView.navigate({
-          create: () => desired[0]!,
+          create: () => leaf,
           clearHistory: true,
           backstackVisible: true,
           transition: transition?.transition || {},
@@ -258,6 +285,40 @@ export default class FrameElement extends NativeElementNode {
       backstackVisible: true,
       transition: transition?.transition || {},
       animated: transition?.animated,
+    });
+  }
+
+  /**
+   * Splices real `BackstackEntry` objects for `ancestors` (outermost first)
+   * into the frame's backstack, below the page it just navigated to,
+   * without running their own `navigate()`/transition/`navigatedTo` cycle.
+   *
+   * Must only run once the triggering `navigate({ clearHistory: true, ... })`
+   * has fully settled - `_updateBackstack`'s `clearHistory` handling tears
+   * down (`resolvedPage = null`) every entry it finds in the backstack at
+   * that point, so splicing any earlier would just have those entries
+   * destroyed again.
+   *
+   * A `BackstackEntry` with no `fragment` is already a real, tolerated
+   * `goBack()` target on Android - `Frame._goBackCore` lazily creates the
+   * fragment on demand (the same path used to recreate fragments the OS
+   * discarded after activity destruction), committing it through a normal
+   * fragment transaction. `fragmentTag` only needs to be unique per frame
+   * (it's how a recreated native fragment re-associates with its JS
+   * backstack entry), and `navDepth` only affects later fragment tags'
+   * cosmetic suffix, not correctness.
+   */
+  private seedBackstack(ancestors: Page[]) {
+    const backStack = (
+      this.nativeView as unknown as { _backStack: BackstackEntry[] }
+    )._backStack;
+    ancestors.forEach((page, index) => {
+      backStack.push({
+        entry: { create: () => page, backstackVisible: true },
+        resolvedPage: page,
+        navDepth: index,
+        fragmentTag: `ember-native-seeded-${syntheticBackstackTagCounter++}`,
+      });
     });
   }
 }


### PR DESCRIPTION
## Summary

Fixes #450. `FrameElement.reconcile()` diffs the desired page stack against the frame's actual backstack + current page. When the common prefix is `0` and the desired stack is more than one level deep (a cross-tree jump straight into a nested route, e.g. reaching `list-view.item` from an unrelated top-level route without ever visiting `list-view` on its own), it previously replayed every intermediate ancestor with its own `navigate()`/transition before the true leaf appeared - one wasted, briefly-visible page + animation per level.

On Android, this now does a single `navigate()` straight to the true leaf, then splices plain `BackstackEntry` objects for the intermediate ancestors into the frame's backstack once that transition settles (`FrameElement.seedBackstack`), instead of running each ancestor through its own transition. `Frame._goBackCore` already tolerates a backstack entry with no native fragment - it lazily creates one on demand (the same path NativeScript uses to recreate a fragment the OS discarded after activity destruction) - so a later `goBack()` into a seeded ancestor still lands on a real, correctly-rendered page.

This is Android-only: iOS's `popToViewControllerAnimated` can only pop to a view controller that was actually pushed, so a synthetic entry there would be an unreachable `goBack()`/edge-swipe target. iOS keeps the existing per-level reconcile behavior.

- `ember-native/src/dom/native/FrameElement.ts`: the fix (`seedBackstack` + the `i === 0` branch change in `reconcile()`)
- `demo-app/app/tests/integration/list-view-stack-test.ts`: new regression test - jumps directly from `/` into `/list-view/a` (skipping `list-view` itself) and asserts a single seeded backstack entry, then verifies `goBack()` to the seeded ancestor renders correctly
- `ember-native/README.md`: documents the new "Cross-tree jumps into a nested route" behavior

## Verification

Since this touches real `Frame`/`BackstackEntry` internals, static reading alone isn't trustworthy here (see the issue's own "needs verification against a real Android Fragment transaction" note) - verified on a real Android emulator via CI, not just locally:
- A diagnostic-logging round (pushed and reverted) confirmed the actual on-device sequence: single `navigate()` → `seedBackstack` → `desired`/`actual` stacks converge with no further native step needed.
- The regression test's `goBack()` to the seeded ancestor entry renders the real `list-view` page (verified via its action-bar title), not a blank/broken fragment.
- Full `app test` CI run: 22/22 tests pass, and the release-boot check still confirms the app boots and renders real content.

## Test plan

- [x] `pnpm exec eslint`/`glint`/`prettier --check` clean on changed files
- [x] `app test` CI (Android emulator): 22/22 tests pass, including the new cross-tree jump regression test
- [x] Release-boot check still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)