### PR TITLE
Collapse multi-level forward frame pushes into a single transition

### DIFF
--- a/demo-app/app/tests/unit/frame-element-test.ts
+++ b/demo-app/app/tests/unit/frame-element-test.ts
@@ -1,6 +1,7 @@
 import { setupRenderingTest } from '~/tests/helpers';
 import { waitUntil } from '@ember/test-helpers';
 import { createElement } from 'ember-native/dom/element-registry';
+import { isAndroid } from '@nativescript/core/platform';
 
 // Regression coverage for `FrameElement`'s reconciler (see its class doc
 // comment in ember-native/src/dom/native/FrameElement.ts) - it drives a
@@ -22,27 +23,34 @@ import { createElement } from 'ember-native/dom/element-registry';
 // machinery by hand, so `FrameElement`'s own constructor-installed listener
 // and `reconcile()` diff logic run for real.
 function installFakeNativeNavigation(nativeFrame: any) {
-  nativeFrame._fakeBackStack = [];
+  // `_backStack` (not a separate fake array) - `FrameElement.seedBackstack`
+  // splices synthetic entries directly into the real Frame's private
+  // `_backStack` field (there's no public API for it), so the fake has to
+  // read/write that same field for a seeded entry to show up through the
+  // public `backStack` getter below.
+  nativeFrame._backStack = [];
   nativeFrame._fakeCurrentEntry = undefined;
+  nativeFrame._navigateCallCount = 0;
 
   Object.defineProperty(nativeFrame, 'backStack', {
     configurable: true,
-    get: () => nativeFrame._fakeBackStack,
+    get: () => nativeFrame._backStack,
   });
   Object.defineProperty(nativeFrame, 'currentPage', {
     configurable: true,
     get: () => nativeFrame._fakeCurrentEntry?.resolvedPage,
   });
 
-  nativeFrame.canGoBack = () => nativeFrame._fakeBackStack.length > 0;
+  nativeFrame.canGoBack = () => nativeFrame._backStack.length > 0;
 
   nativeFrame.navigate = (options: any) => {
+    nativeFrame._navigateCallCount++;
     queueMicrotask(() => {
       const prevEntry = nativeFrame._fakeCurrentEntry;
       if (options.clearHistory) {
-        nativeFrame._fakeBackStack = [];
+        nativeFrame._backStack = [];
       } else if (prevEntry) {
-        nativeFrame._fakeBackStack = [...nativeFrame._fakeBackStack, prevEntry];
+        nativeFrame._backStack = [...nativeFrame._backStack, prevEntry];
       }
       const entry = { resolvedPage: options.create(), entry: options };
       nativeFrame._fakeCurrentEntry = entry;
@@ -57,8 +65,8 @@ function installFakeNativeNavigation(nativeFrame: any) {
 
   nativeFrame.goBack = (backstackEntry: any) => {
     queueMicrotask(() => {
-      const index = nativeFrame._fakeBackStack.indexOf(backstackEntry);
-      nativeFrame._fakeBackStack = nativeFrame._fakeBackStack.slice(0, index);
+      const index = nativeFrame._backStack.indexOf(backstackEntry);
+      nativeFrame._backStack = nativeFrame._backStack.slice(0, index);
       nativeFrame._fakeCurrentEntry = backstackEntry;
       nativeFrame.notify({
         eventName: 'navigatedTo',
@@ -169,6 +177,63 @@ QUnit.module('FrameElement | real Frame backstack', function (hooks) {
       );
       assert.strictEqual(frame.nativeView.currentPage, page1.nativeView);
       assert.false(frame.nativeView.canGoBack());
+    },
+  );
+
+  QUnit.test(
+    'pushing two nested pages in the same batch collapses into a single native step on Android',
+    async function (assert) {
+      // Simulates a single Ember route transition that activates two
+      // nested routes at once (both `<page>`s land in `childNodes` before
+      // `reconcile()` gets a microtask to look at either) - the scenario
+      // `navigateToLeaf`'s skip-ahead-and-seed path exists for (see
+      // `FrameElement`'s class doc comment and `navigateToLeaf`).
+      const frame = createElement('frame');
+      installFakeNativeNavigation(frame.nativeView);
+      const page1 = createElement('page');
+      const page2 = createElement('page');
+      const page3 = createElement('page');
+
+      frame.appendChild(page1);
+      await waitUntil(() => frame.nativeView.currentPage === page1.nativeView);
+
+      frame.appendChild(page2);
+      frame.appendChild(page3);
+      await waitUntil(() => frame.nativeView.currentPage === page3.nativeView);
+
+      const navigateCallCount = (frame.nativeView as any)._navigateCallCount;
+      if (isAndroid) {
+        assert.strictEqual(
+          navigateCallCount,
+          2,
+          'one navigate() for the initial page1 mount, one for the collapsed page2+page3 push',
+        );
+        assert.strictEqual(frame.nativeView.backStack.length, 2);
+        assert.strictEqual(frame.nativeView.backStack[0]?.resolvedPage, page1.nativeView);
+        assert.strictEqual(
+          frame.nativeView.backStack[1]?.resolvedPage,
+          page2.nativeView,
+          'page2 was seeded into the backstack even though it never ran its own transition',
+        );
+      } else {
+        assert.strictEqual(
+          navigateCallCount,
+          3,
+          'iOS steps through page2 before page3 - a synthetic backstack entry would be an unreachable popToViewController target',
+        );
+      }
+
+      // Going back should land on page2, whether it got there via a seeded
+      // entry (Android) or its own transition (iOS) - either way it's the
+      // same page2 instance, not a fresh one.
+      frame.removeChild(page3);
+      await waitUntil(() => frame.nativeView.currentPage === page2.nativeView);
+      assert.strictEqual(frame.nativeView.backStack.length, 1);
+
+      frame.removeChild(page2);
+      await waitUntil(
+        () => frame.nativeView.currentPage === page1.nativeView && !frame.nativeView.canGoBack(),
+      );
     },
   );
 });

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -330,6 +330,28 @@ once. (An earlier version of this file noted that a second `navigate()` to
 an already-used `Page` instance was unreliable on-device - this design
 doesn't do that; avoiding it is the reason `goBack()` exists at all.)
 
+### Forward pushes across several nested routes at once
+
+The same `navigateToLeaf` step used for cross-tree jumps also applies when
+the frame is already showing a valid prefix of the desired stack but the
+route transition activates more than one new nested route beyond it in a
+single go (e.g. a deep link or a programmatic transition landing two levels
+deeper than whatever's currently on screen). Naively, `reconcile()`'s normal
+one-step-at-a-time loop would push each new page in its own `navigate()` and
+wait for it to fully settle before pushing the next - N sequential animated
+transitions, each one briefly showing an intermediate page the user never
+meant to stop on, adding real, visible delay on top of the (expected,
+by-design) cost of the animation itself.
+
+On Android, `reconcile()` avoids this the same way it avoids it for
+cross-tree jumps: a single `navigate()` straight to the true leaf, with the
+skipped intermediate pages spliced into the backstack via `seedBackstack`
+once that transition settles, instead of running each of them through its
+own `navigate()`. This is Android-only, for the same reason as the
+cross-tree case: iOS's `popToViewControllerAnimated` can only pop to a view
+controller that was actually pushed, so iOS still steps through each
+intermediate page with its own transition.
+
 ### Sub-routes, via `FrameOutlet`
 
 Ember never tears down a route's rendered output while any of its child

--- a/ember-native/src/dom/native/FrameElement.ts
+++ b/ember-native/src/dom/native/FrameElement.ts
@@ -65,19 +65,30 @@ export function setOnUnexpectedBack(handler: (() => void) | null) {
  * it's actually done) and performs exactly one native step - either
  * `navigate()` or `goBack()` - then waits for the frame's own
  * `navigatedTo` event (which only fires once a queued navigation has truly
- * settled) before checking again. Re-diffing after every settle, instead
- * of computing a fixed list of steps up front, means it self-heals even if
- * Ember makes several changes before the frame catches up - e.g. a fast
- * forward-then-back collapses to a no-op once the drain finishes.
+ * settled, i.e. its transition has finished animating) before checking
+ * again. Re-diffing after every settle, instead of computing a fixed list
+ * of steps up front, means it self-heals even if Ember makes several
+ * changes before the frame catches up - e.g. a fast forward-then-back
+ * collapses to a no-op once the drain finishes.
+ *
+ * Because a step only completes once its transition finishes animating,
+ * more than one native step for a single Ember change (e.g. a route
+ * transition that activates several nested routes at once, so more than
+ * one new `<page>` appears in the same synchronous batch) would mean
+ * several full transitions playing back to back. `navigateToLeaf` avoids
+ * that on Android by jumping straight to the deepest page in one
+ * transition and backfilling the skipped pages into the backstack
+ * afterward (see `seedBackstack`) - see its own doc comment for why this
+ * can't apply on iOS.
  */
 export default class FrameElement extends NativeElementNode {
   private reconcileScheduled = false;
   private reconciling = false;
   private pendingTransition: typeof nextTransition = null;
-  // Set right before a cross-tree jump's single `navigate()` call settles -
-  // see the `i === 0` branch in `reconcile()` and `seedBackstack()` below.
-  // Holds the ancestor pages (outermost first) that still need a real
-  // backstack entry even though they never got their own transition.
+  // Set right before a `navigateToLeaf()` call that skipped over one or more
+  // intermediate pages settles - see `reconcile()` and `seedBackstack()`
+  // below. Holds those skipped pages (outermost first), which still need a
+  // real backstack entry even though they never got their own transition.
   private pendingBackstackSeed: Page[] | null = null;
 
   constructor() {
@@ -250,38 +261,53 @@ export default class FrameElement extends NativeElementNode {
       // top-level route in one go) - there's nothing to go back *to* in
       // that case, so replace the stack's base outright instead.
       if (i === 0) {
-        // Cross-tree jump straight into a nested route (`desired.length > 1`):
-        // on Android, do a single native transition straight to the true
-        // leaf and splice synthetic `BackstackEntry` objects for the
-        // intermediate ancestors into the backstack once it settles (see
-        // `seedBackstack`), instead of materializing each ancestor with its
-        // own transition first. iOS's `popToViewControllerAnimated` can only
-        // pop to a view controller that was actually pushed, so a synthetic
-        // entry there would be an unreachable `goBack()`/edge-swipe target -
-        // iOS keeps stepping through each ancestor instead.
-        const seedAncestors = isAndroid && desired.length > 1;
-        if (seedAncestors) {
-          this.pendingBackstackSeed = desired.slice(0, -1);
-        }
-        const leaf = seedAncestors ? desired[desired.length - 1]! : desired[0]!;
-        this.nativeView.navigate({
-          create: () => leaf,
-          clearHistory: true,
-          backstackVisible: true,
-          transition: transition?.transition || {},
-          animated: transition?.animated,
-        });
+        // Cross-tree jump straight into a nested route (`desired.length > 1`).
+        this.navigateToLeaf(desired, 0, true, transition);
       } else {
         this.nativeView.goBack(backStack[i - 1]);
       }
       return;
     }
 
-    // Everything the frame currently shows is still wanted - push the next
-    // desired page on top.
+    // Everything the frame currently shows is still wanted - push forward
+    // to the next desired page(s).
+    this.navigateToLeaf(desired, i, false, transition);
+  }
+
+  /**
+   * Navigates in a single native step from wherever the frame currently is
+   * to `desired[desired.length - 1]`, even when that skips over one or more
+   * pages in `desired.slice(fromIndex)` that never got their own transition
+   * - e.g. a cross-tree jump straight into a nested route (`fromIndex === 0`
+   * with `clearHistory: true`), or an Ember transition that activates
+   * several nested routes deeper than the currently-active one in one go
+   * (`fromIndex > 0` with `clearHistory: false`). Each skipped page still
+   * needs a real backstack entry so `goBack()`/edge-swipe later lands on it
+   * correctly - that's what `seedBackstack` (spliced in once this
+   * `navigate()` settles - see the `navigatedTo` handler above) is for.
+   *
+   * Only on Android: iOS's `popToViewControllerAnimated` can only pop to a
+   * view controller that was actually pushed, so a synthetic entry there
+   * would be an unreachable `goBack()`/edge-swipe target - iOS keeps
+   * stepping through each intermediate page with its own transition
+   * instead, via `reconcile()`'s normal one-step-at-a-time loop.
+   */
+  private navigateToLeaf(
+    desired: Page[],
+    fromIndex: number,
+    clearHistory: boolean,
+    transition: typeof nextTransition,
+  ) {
+    const seedSkipped = isAndroid && desired.length - fromIndex > 1;
+    if (seedSkipped) {
+      this.pendingBackstackSeed = desired.slice(fromIndex, -1);
+    }
+    const leaf = seedSkipped
+      ? desired[desired.length - 1]!
+      : desired[fromIndex]!;
     this.nativeView.navigate({
-      create: () => desired[i]!,
-      clearHistory: false,
+      create: () => leaf,
+      clearHistory,
       backstackVisible: true,
       transition: transition?.transition || {},
       animated: transition?.animated,
@@ -289,15 +315,18 @@ export default class FrameElement extends NativeElementNode {
   }
 
   /**
-   * Splices real `BackstackEntry` objects for `ancestors` (outermost first)
-   * into the frame's backstack, below the page it just navigated to,
-   * without running their own `navigate()`/transition/`navigatedTo` cycle.
+   * Splices real `BackstackEntry` objects for `pages` (outermost first)
+   * into the frame's backstack, below the page `navigateToLeaf` just
+   * navigated to, without running their own `navigate()`/transition/
+   * `navigatedTo` cycle.
    *
-   * Must only run once the triggering `navigate({ clearHistory: true, ... })`
-   * has fully settled - `_updateBackstack`'s `clearHistory` handling tears
+   * Must only run once the triggering `navigate()` has fully settled - with
+   * `clearHistory: true`, `_updateBackstack`'s clearHistory handling tears
    * down (`resolvedPage = null`) every entry it finds in the backstack at
    * that point, so splicing any earlier would just have those entries
-   * destroyed again.
+   * destroyed again; with `clearHistory: false`, splicing early would race
+   * `_updateBackstack`'s own push of the previously-current entry, landing
+   * these pages in the wrong order.
    *
    * A `BackstackEntry` with no `fragment` is already a real, tolerated
    * `goBack()` target on Android - `Frame._goBackCore` lazily creates the
@@ -308,11 +337,11 @@ export default class FrameElement extends NativeElementNode {
    * backstack entry), and `navDepth` only affects later fragment tags'
    * cosmetic suffix, not correctness.
    */
-  private seedBackstack(ancestors: Page[]) {
+  private seedBackstack(pages: Page[]) {
     const backStack = (
       this.nativeView as unknown as { _backStack: BackstackEntry[] }
     )._backStack;
-    ancestors.forEach((page, index) => {
+    pages.forEach((page, index) => {
       backStack.push({
         entry: { create: () => page, backstackVisible: true },
         resolvedPage: page,


### PR DESCRIPTION
## Summary
- `FrameElement.reconcile()` only ever performed one native `navigate()` step at a time, waiting for the frame's `navigatedTo` event (which fires once the transition has finished *animating*, confirmed by reading `@nativescript/core`'s `transitionOrAnimationCompleted`) before taking the next. When a single Ember route transition activates more than one nested route at once (e.g. deep-linking, or a router transition that skips straight into a doubly-nested route), this meant several full animated transitions playing back to back - a real, avoidable source of navigation delay.
- Generalizes the cross-tree-jump optimization already used in the `i === 0` branch (added in #451) into a shared `navigateToLeaf()`: on Android, jump straight to the deepest newly-desired page in a single native transition and splice the skipped intermediate pages into the backstack afterward via the existing `seedBackstack()`, instead of materializing each one with its own transition. iOS is unaffected - it keeps the old one-step-at-a-time behavior, since `popToViewControllerAnimated` can't target a view controller that was never actually pushed.
- Verified via static reading of the installed `@nativescript/core` fragment-transition code that this doesn't change per-step animation cost (an empty `transition: {}` resolves to the same 150ms default fade as omitting it entirely) - the win is purely in collapsing N sequential transitions into 1 for the multi-level-in-one-batch case.

## Test plan
- [x] `pnpm lint` / `pnpm exec eslint` / `pnpm exec glint` clean in both `ember-native` and `demo-app`
- [x] `pnpm build` (ember-native) succeeds
- [x] New `frame-element-test.ts` case ("pushing two nested pages in the same batch collapses into a single native step on Android") exercises the collapsed path deterministically via the existing fake-native-navigation harness, plus the existing `list-view-stack-test.ts`/`frame-element-test.ts` suites for regressions - pending real CI (Android emulator) run

🤖 Generated with [Claude Code](https://claude.com/claude-code)