### PR TITLE
Fix permanent frame navigation freeze from seeded backstack entries

### DIFF
--- a/demo-app/app/tests/integration/list-view-stack-test.ts
+++ b/demo-app/app/tests/integration/list-view-stack-test.ts
@@ -117,7 +117,8 @@ QUnit.module('Acceptance | list-view page stack', function (hooks) {
       // the route we're about to jump into) is never visited on its own, so
       // `FrameElement.reconcile()` sees a common-prefix-zero jump into a
       // 2-deep desired stack (`list-view` + `list-view.item`) - the case
-      // `seedBackstack` exists for (see `FrameElement.ts`).
+      // `navigateToLeaf`'s multi-page batching exists for (see
+      // `FrameElement.ts`).
       await visit('/');
       const frame: Frame = ENV.rootElement.getElementByTagName('frame').nativeView;
       await waitUntil(() => !!frame.currentPage, { timeout: 5000 });
@@ -146,11 +147,11 @@ QUnit.module('Acceptance | list-view page stack', function (hooks) {
         'the seeded backstack entry is the same list-view Page instance Ember rendered'
       );
 
-      // The discriminating check: a `BackstackEntry` `seedBackstack` spliced
-      // in never went through its own `navigate()`/fragment transaction -
-      // going back to it is what actually proves the lazily-created
-      // fragment/view-controller renders on a real device, not just that
-      // the JS-level `backStack` array looks right.
+      // The discriminating check: `list-view`'s own page got an unanimated
+      // `navigate()` batched ahead of `list-view.item`'s (see
+      // `navigateToLeaf`) - going back to it is what actually proves that
+      // real, queued `navigate()` renders and settles correctly on a real
+      // device, not just that the JS-level `backStack` array looks right.
       //
       // Not `history.back()`: `HistoryService`'s stack recorded a single
       // entry for the whole `/` -> `/list-view/a` jump (one router
@@ -171,6 +172,38 @@ QUnit.module('Acceptance | list-view page stack', function (hooks) {
       assert.false(
         frame.canGoBack(),
         'the backstack is empty again after going back to the seeded root'
+      );
+
+      // The actual regression this guards against: landing back on a page
+      // that was pushed via an unanimated, batched `navigate()` (rather
+      // than its own `reconcile()` step) must not leave `FrameElement`'s
+      // `reconciling` flag stuck. If it did, this next forward navigate()
+      // would never resolve, and - since `reconcile()` only ever runs again
+      // from the settle handler of a navigation that itself never settles -
+      // every future route change anywhere in the app would silently stop
+      // working too. Asserting on `frame.currentPage`/`frame.backStack`
+      // (not just DOM-shim state) matters here: a stuck `reconciling` still
+      // leaves `childNodes` looking correct, since Ember's own render
+      // already happened.
+      await visit('/list-view/a');
+      const itemPageAgain = ENV.rootElement.getElementById('item-page');
+      const itemPageAgainNativeView: Page = itemPageAgain?.nativeView;
+      await waitUntil(() => frame.currentPage === itemPageAgainNativeView, {
+        timeout: 5000,
+      });
+
+      assert.true(
+        !!itemPageAgain?.getElementByTagName('actionbar')?.getAttribute('title')?.startsWith('Item'),
+        'navigating forward again after landing on the seeded entry still reaches the item route'
+      );
+      assert.true(
+        frame.canGoBack(),
+        'the seeded list page is back on the real Frame backstack after the second forward navigate'
+      );
+      assert.equal(
+        frame.backStack.length,
+        1,
+        'exactly one backstack entry again - the list page'
       );
     }
   );

--- a/demo-app/app/tests/unit/frame-element-test.ts
+++ b/demo-app/app/tests/unit/frame-element-test.ts
@@ -1,7 +1,6 @@
 import { setupRenderingTest } from '~/tests/helpers';
 import { waitUntil } from '@ember/test-helpers';
 import { createElement } from 'ember-native/dom/element-registry';
-import { isAndroid } from '@nativescript/core/platform';
 
 // Regression coverage for `FrameElement`'s reconciler (see its class doc
 // comment in ember-native/src/dom/native/FrameElement.ts) - it drives a
@@ -23,11 +22,6 @@ import { isAndroid } from '@nativescript/core/platform';
 // machinery by hand, so `FrameElement`'s own constructor-installed listener
 // and `reconcile()` diff logic run for real.
 function installFakeNativeNavigation(nativeFrame: any) {
-  // `_backStack` (not a separate fake array) - `FrameElement.seedBackstack`
-  // splices synthetic entries directly into the real Frame's private
-  // `_backStack` field (there's no public API for it), so the fake has to
-  // read/write that same field for a seeded entry to show up through the
-  // public `backStack` getter below.
   nativeFrame._backStack = [];
   nativeFrame._fakeCurrentEntry = undefined;
   nativeFrame._navigateCallCount = 0;
@@ -181,12 +175,12 @@ QUnit.module('FrameElement | real Frame backstack', function (hooks) {
   );
 
   QUnit.test(
-    'pushing two nested pages in the same batch collapses into a single native step on Android',
+    'pushing two nested pages in the same batch settles as one reconcile step on Android',
     async function (assert) {
       // Simulates a single Ember route transition that activates two
       // nested routes at once (both `<page>`s land in `childNodes` before
       // `reconcile()` gets a microtask to look at either) - the scenario
-      // `navigateToLeaf`'s skip-ahead-and-seed path exists for (see
+      // `navigateToLeaf`'s batched-`navigate()` path exists for (see
       // `FrameElement`'s class doc comment and `navigateToLeaf`).
       const frame = createElement('frame');
       installFakeNativeNavigation(frame.nativeView);
@@ -201,31 +195,25 @@ QUnit.module('FrameElement | real Frame backstack', function (hooks) {
       frame.appendChild(page3);
       await waitUntil(() => frame.nativeView.currentPage === page3.nativeView);
 
+      // Both platforms end up issuing a real `navigate()` per page (one for
+      // page1's initial mount, one each for page2/page3) - what differs is
+      // *when*: on Android, `navigateToLeaf` issues page2's and page3's
+      // `navigate()` calls back to back in the same synchronous batch
+      // (page2's unanimated, only page3's animated), relying on `Frame`'s
+      // own internal navigation queue to serialize them, instead of waiting
+      // for a full `reconcile()`/settle round trip between them the way iOS
+      // does.
       const navigateCallCount = (frame.nativeView as any)._navigateCallCount;
-      if (isAndroid) {
-        assert.strictEqual(
-          navigateCallCount,
-          2,
-          'one navigate() for the initial page1 mount, one for the collapsed page2+page3 push',
-        );
-        assert.strictEqual(frame.nativeView.backStack.length, 2);
-        assert.strictEqual(frame.nativeView.backStack[0]?.resolvedPage, page1.nativeView);
-        assert.strictEqual(
-          frame.nativeView.backStack[1]?.resolvedPage,
-          page2.nativeView,
-          'page2 was seeded into the backstack even though it never ran its own transition',
-        );
-      } else {
-        assert.strictEqual(
-          navigateCallCount,
-          3,
-          'iOS steps through page2 before page3 - a synthetic backstack entry would be an unreachable popToViewController target',
-        );
-      }
+      assert.strictEqual(navigateCallCount, 3);
+      assert.strictEqual(frame.nativeView.backStack.length, 2);
+      assert.strictEqual(frame.nativeView.backStack[0]?.resolvedPage, page1.nativeView);
+      assert.strictEqual(
+        frame.nativeView.backStack[1]?.resolvedPage,
+        page2.nativeView,
+        'page2 landed on the real backstack even though its own navigate() never left this batch',
+      );
 
-      // Going back should land on page2, whether it got there via a seeded
-      // entry (Android) or its own transition (iOS) - either way it's the
-      // same page2 instance, not a fresh one.
+      // Going back should land on page2, the same instance either way.
       frame.removeChild(page3);
       await waitUntil(() => frame.nativeView.currentPage === page2.nativeView);
       assert.strictEqual(frame.nativeView.backStack.length, 1);
@@ -233,6 +221,18 @@ QUnit.module('FrameElement | real Frame backstack', function (hooks) {
       frame.removeChild(page2);
       await waitUntil(
         () => frame.nativeView.currentPage === page1.nativeView && !frame.nativeView.canGoBack(),
+      );
+
+      // The actual regression this guards against: landing on a page that
+      // arrived via an unanimated, batched `navigate()` must not leave
+      // `FrameElement`'s reconciling lifecycle stuck - a further forward
+      // push afterward has to settle too.
+      frame.appendChild(page2);
+      await waitUntil(() => frame.nativeView.currentPage === page2.nativeView);
+      assert.strictEqual(
+        frame.nativeView.currentPage,
+        page2.nativeView,
+        'navigating forward again after the batched push still settles',
       );
     },
   );

--- a/ember-native/README.md
+++ b/ember-native/README.md
@@ -307,28 +307,39 @@ settle, push `list-view.item`, settle - materializing and briefly displaying
 the parent page's own transition/animation on the way to a destination that
 was never `list-view` itself.
 
-On Android, `reconcile()` avoids this: it does a single `navigate()` straight
-to the true leaf (`list-view.item`), then splices plain `BackstackEntry`
-objects for the intermediate ancestors (`list-view`) directly into the
-frame's backstack once that transition settles, instead of running each
-ancestor through its own `navigate()`. `Frame._goBackCore` already tolerates
-a backstack entry with no native fragment - it creates one on demand (the
-same path used to recreate a fragment the OS discarded after the activity
-was destroyed) - so a `goBack()`/`HistoryService#back()` into a seeded
-ancestor still lands on a real, correctly-rendered page, confirmed on-device
-via `demo-app/app/tests/integration/list-view-stack-test.ts`'s cross-tree
-jump test. This is Android-only: iOS's `popToViewControllerAnimated` can
-only pop to a view controller that was actually pushed, so a synthetic entry
-there would be an unreachable target - iOS still steps through each
-ancestor.
+On Android, `reconcile()` avoids playing a full animated transition per
+level: `navigateToLeaf` issues a real `navigate()` for every intermediate
+ancestor (`list-view`) *and* the true leaf (`list-view.item`) back to back,
+in the same synchronous batch, instead of waiting for each one to fully
+settle before issuing the next - only the last (real destination) call is
+animated, the rest pass `animated: false` via `Frame`'s own internal
+navigation queue. Each intermediate page still runs its own real fragment
+transaction/layout pass and can be visible for a frame or two while queued
+ones resolve - what this avoids is N full timed transition animations
+playing back to back, not the underlying native work itself (no perf
+measurement backs a stronger claim than that). Confirmed on-device, via
+`demo-app/app/tests/integration/list-view-stack-test.ts`'s cross-tree jump
+test, that `goBack()`/`HistoryService#back()` into `list-view` afterward
+lands on a real, correctly-rendered page - and, critically, that a further
+forward navigate afterward still settles too. This is Android-only: iOS's
+`popToViewControllerAnimated` can only pop to a view controller that was
+actually pushed, so queuing unanimated pushes ahead of time doesn't help
+there - iOS still steps through each ancestor with its own transition.
 
-One consequence of this design: a page is only ever pushed with a *fresh*
-`Page` instance (whatever Ember just created) - going back always uses
-`goBack()`, resuming the frame's own preserved backstack entry, never a
-second `navigate()` to a `Page` instance that's already been backstacked
-once. (An earlier version of this file noted that a second `navigate()` to
-an already-used `Page` instance was unreliable on-device - this design
-doesn't do that; avoiding it is the reason `goBack()` exists at all.)
+An earlier version of this instead issued a single real `navigate()` to the
+leaf and spliced synthetic, fragment-less `BackstackEntry` objects for the
+skipped ancestors directly into `Frame`'s private `_backStack`. That was
+cheaper, but those synthetic entries never went through
+`_setAndroidFragmentTransitions`, so they had no enter/exit/reenter/return
+transition listeners of their own - `goBack()`-ing onto one left
+NativeScript's Android transition bookkeeping
+(`fragment.transitions.android.js`'s `waitingQueue`, keyed by `frameId` and
+expecting a matched pair of listeners per step) with only one side ever
+registering, which could desync a subsequent navigation and permanently
+freeze the frame's `reconcile()` loop (every future route change anywhere in
+the app silently stopped working). Every page is now pushed via a real
+`navigate()`, so every backstack entry gets the same paired listener setup
+as any other, closing that whole bug class.
 
 ### Forward pushes across several nested routes at once
 
@@ -344,13 +355,13 @@ meant to stop on, adding real, visible delay on top of the (expected,
 by-design) cost of the animation itself.
 
 On Android, `reconcile()` avoids this the same way it avoids it for
-cross-tree jumps: a single `navigate()` straight to the true leaf, with the
-skipped intermediate pages spliced into the backstack via `seedBackstack`
-once that transition settles, instead of running each of them through its
-own `navigate()`. This is Android-only, for the same reason as the
-cross-tree case: iOS's `popToViewControllerAnimated` can only pop to a view
-controller that was actually pushed, so iOS still steps through each
-intermediate page with its own transition.
+cross-tree jumps: `navigateToLeaf` issues a real, unanimated `navigate()`
+for each skipped page and an animated one for the true leaf, all back to
+back in the same batch, instead of running each of them through its own
+fully-settled `navigate()`/transition round trip. This is Android-only, for
+the same reason as the cross-tree case: iOS's `popToViewControllerAnimated`
+can only pop to a view controller that was actually pushed, so iOS still
+steps through each intermediate page with its own transition.
 
 ### Sub-routes, via `FrameOutlet`
 

--- a/ember-native/src/dom/native/FrameElement.ts
+++ b/ember-native/src/dom/native/FrameElement.ts
@@ -1,14 +1,11 @@
 import { Frame } from '@nativescript/core/ui/frame';
 import type { NavigationTransition, View } from '@nativescript/core';
 import { isAndroid } from '@nativescript/core/platform';
-import type { BackstackEntry } from '@nativescript/core/ui/frame/frame-interfaces';
 
 import { createElement } from '../element-registry.ts';
 import ViewNode from '../nodes/ViewNode.ts';
 import NativeElementNode from './NativeElementNode.ts';
 import { Page } from '@nativescript/core/ui/page';
-
-let syntheticBackstackTagCounter = 0;
 
 let nextTransition: {
   transition: NavigationTransition | undefined;
@@ -75,21 +72,52 @@ export function setOnUnexpectedBack(handler: (() => void) | null) {
  * more than one native step for a single Ember change (e.g. a route
  * transition that activates several nested routes at once, so more than
  * one new `<page>` appears in the same synchronous batch) would mean
- * several full transitions playing back to back. `navigateToLeaf` avoids
- * that on Android by jumping straight to the deepest page in one
- * transition and backfilling the skipped pages into the backstack
- * afterward (see `seedBackstack`) - see its own doc comment for why this
- * can't apply on iOS.
+ * several full *animated* transitions playing back to back. `navigateToLeaf`
+ * avoids that specific cost on Android by issuing every skipped page's
+ * `navigate()` up front with no animation and animating only the last, real
+ * destination - see its own doc comment for why this can't apply on iOS.
+ * Each skipped page still runs its own real fragment transaction/layout
+ * pass via `Frame`'s own internal navigation queue (see its own doc
+ * comment), so it can still be visible for a frame or two; what this avoids
+ * is each one playing a full, timed transition animation, not fragment
+ * construction/layout itself - no perf measurement backs a stronger claim
+ * than that.
+ *
+ * An earlier version of this instead issued a single real `navigate()` to
+ * the leaf and spliced synthetic, fragment-less `BackstackEntry` objects
+ * for the skipped pages directly into `Frame`'s private `_backStack` -
+ * cheaper, but those synthetic entries never went through
+ * `_setAndroidFragmentTransitions`, so they had no enter/exit/reenter/
+ * return transition listeners of their own. `goBack()`-ing onto one left
+ * NativeScript's Android transition bookkeeping
+ * (`fragment.transitions.android.js`'s `waitingQueue`, keyed by
+ * `entry.frameId` and expecting a matched pair of listeners per step) with
+ * only one side ever registering, permanently corrupting it for every
+ * navigation on that frame afterward. Every page this class now creates
+ * goes through a real `navigate()`, so every backstack entry gets the same
+ * paired listener setup as any other - that whole bug class no longer has
+ * anywhere to live.
  */
 export default class FrameElement extends NativeElementNode {
   private reconcileScheduled = false;
   private reconciling = false;
   private pendingTransition: typeof nextTransition = null;
-  // Set right before a `navigateToLeaf()` call that skipped over one or more
-  // intermediate pages settles - see `reconcile()` and `seedBackstack()`
-  // below. Holds those skipped pages (outermost first), which still need a
-  // real backstack entry even though they never got their own transition.
-  private pendingBackstackSeed: Page[] | null = null;
+  // How many still-queued `navigate()` calls a single `reconcile()` step
+  // issued (see `navigateToLeaf`) - `Frame`'s own internal navigation queue
+  // fires `navigatedToEvent` once per settled call, but only the *last* one
+  // in a batch means the frame has actually caught up with `childNodes`;
+  // earlier ones just let `Frame` know it's free to start the next queued
+  // call, decremented rather than acted on.
+  //
+  // This relies on every queued `navigate()` eventually firing its own
+  // `navigatedToEvent` exactly once - if any of them were ever silently
+  // dropped (e.g. by `_processNavigationQueue`'s `page !== currentNavigationPage`
+  // identity check skipping it), this count would never reach 1 again and
+  // `reconciling` would stay stuck `true` forever, the same permanent freeze
+  // this whole mechanism replaced (see the class doc comment). Not otherwise
+  // guarded against here - no case where a page created and queued by this
+  // class's own `navigate()` calls fails to settle has been observed.
+  private pendingSettleCount = 1;
 
   constructor() {
     super('frame', Frame, null);
@@ -104,11 +132,12 @@ export default class FrameElement extends NativeElementNode {
         }
         return;
       }
-      this.reconciling = false;
-      if (this.pendingBackstackSeed) {
-        this.seedBackstack(this.pendingBackstackSeed);
-        this.pendingBackstackSeed = null;
+      if (this.pendingSettleCount > 1) {
+        this.pendingSettleCount--;
+        return;
       }
+      this.pendingSettleCount = 1;
+      this.reconciling = false;
       this.reconcile();
     });
   }
@@ -264,6 +293,7 @@ export default class FrameElement extends NativeElementNode {
         // Cross-tree jump straight into a nested route (`desired.length > 1`).
         this.navigateToLeaf(desired, 0, true, transition);
       } else {
+        this.pendingSettleCount = 1;
         this.nativeView.goBack(backStack[i - 1]);
       }
       return;
@@ -275,22 +305,37 @@ export default class FrameElement extends NativeElementNode {
   }
 
   /**
-   * Navigates in a single native step from wherever the frame currently is
-   * to `desired[desired.length - 1]`, even when that skips over one or more
+   * Navigates from wherever the frame currently is to
+   * `desired[desired.length - 1]`, even when that skips over one or more
    * pages in `desired.slice(fromIndex)` that never got their own transition
    * - e.g. a cross-tree jump straight into a nested route (`fromIndex === 0`
    * with `clearHistory: true`), or an Ember transition that activates
    * several nested routes deeper than the currently-active one in one go
-   * (`fromIndex > 0` with `clearHistory: false`). Each skipped page still
-   * needs a real backstack entry so `goBack()`/edge-swipe later lands on it
-   * correctly - that's what `seedBackstack` (spliced in once this
-   * `navigate()` settles - see the `navigatedTo` handler above) is for.
+   * (`fromIndex > 0` with `clearHistory: false`).
+   *
+   * On Android, every skipped page still gets a real `navigate()` call -
+   * each one is queued (via `Frame`'s own internal `_navigationQueue`,
+   * simply by calling `navigate()` again before the previous one has
+   * settled) with no animation, so none of them plays a full timed
+   * transition; only the last, real destination animates. Each one still
+   * runs its own real fragment transaction/layout pass and can be visible
+   * for a frame or two while queued ones resolve - what this avoids is N
+   * full animated transitions playing back to back, not the underlying
+   * native work itself. This keeps every backstack entry a genuine one (its
+   * own fragment, its own paired transition listeners), just as if
+   * `reconcile()` had stepped through them one settle at a time - avoiding
+   * the synthetic, listener-less backstack entries an earlier version of
+   * this spliced in directly, which could desync `Frame`'s own transition
+   * bookkeeping and permanently freeze the frame (see the class doc
+   * comment).
    *
    * Only on Android: iOS's `popToViewControllerAnimated` can only pop to a
-   * view controller that was actually pushed, so a synthetic entry there
-   * would be an unreachable `goBack()`/edge-swipe target - iOS keeps
-   * stepping through each intermediate page with its own transition
-   * instead, via `reconcile()`'s normal one-step-at-a-time loop.
+   * view controller that was actually pushed, so queuing several
+   * unanimated pushes ahead of time doesn't help there the way it does on
+   * Android - iOS keeps stepping through each intermediate page with its
+   * own animated transition instead, via `reconcile()`'s normal
+   * one-step-at-a-time loop (this method navigates to just
+   * `desired[fromIndex]` there).
    */
   private navigateToLeaf(
     desired: Page[],
@@ -298,55 +343,16 @@ export default class FrameElement extends NativeElementNode {
     clearHistory: boolean,
     transition: typeof nextTransition,
   ) {
-    const seedSkipped = isAndroid && desired.length - fromIndex > 1;
-    if (seedSkipped) {
-      this.pendingBackstackSeed = desired.slice(fromIndex, -1);
-    }
-    const leaf = seedSkipped
-      ? desired[desired.length - 1]!
-      : desired[fromIndex]!;
-    this.nativeView.navigate({
-      create: () => leaf,
-      clearHistory,
-      backstackVisible: true,
-      transition: transition?.transition || {},
-      animated: transition?.animated,
-    });
-  }
-
-  /**
-   * Splices real `BackstackEntry` objects for `pages` (outermost first)
-   * into the frame's backstack, below the page `navigateToLeaf` just
-   * navigated to, without running their own `navigate()`/transition/
-   * `navigatedTo` cycle.
-   *
-   * Must only run once the triggering `navigate()` has fully settled - with
-   * `clearHistory: true`, `_updateBackstack`'s clearHistory handling tears
-   * down (`resolvedPage = null`) every entry it finds in the backstack at
-   * that point, so splicing any earlier would just have those entries
-   * destroyed again; with `clearHistory: false`, splicing early would race
-   * `_updateBackstack`'s own push of the previously-current entry, landing
-   * these pages in the wrong order.
-   *
-   * A `BackstackEntry` with no `fragment` is already a real, tolerated
-   * `goBack()` target on Android - `Frame._goBackCore` lazily creates the
-   * fragment on demand (the same path used to recreate fragments the OS
-   * discarded after activity destruction), committing it through a normal
-   * fragment transaction. `fragmentTag` only needs to be unique per frame
-   * (it's how a recreated native fragment re-associates with its JS
-   * backstack entry), and `navDepth` only affects later fragment tags'
-   * cosmetic suffix, not correctness.
-   */
-  private seedBackstack(pages: Page[]) {
-    const backStack = (
-      this.nativeView as unknown as { _backStack: BackstackEntry[] }
-    )._backStack;
+    const pages = isAndroid ? desired.slice(fromIndex) : [desired[fromIndex]!];
+    this.pendingSettleCount = pages.length;
     pages.forEach((page, index) => {
-      backStack.push({
-        entry: { create: () => page, backstackVisible: true },
-        resolvedPage: page,
-        navDepth: index,
-        fragmentTag: `ember-native-seeded-${syntheticBackstackTagCounter++}`,
+      const isLeaf = index === pages.length - 1;
+      this.nativeView.navigate({
+        create: () => page,
+        clearHistory: clearHistory && index === 0,
+        backstackVisible: true,
+        transition: isLeaf ? transition?.transition || {} : {},
+        animated: isLeaf ? transition?.animated : false,
       });
     });
   }


### PR DESCRIPTION
## Summary
- `FrameElement.reconcile()`'s `navigateToLeaf()` (added in #451, generalized in #459) spliced synthetic, fragment-less `BackstackEntry` objects directly into `Frame._backStack` for skipped ancestor pages, to avoid one native transition per level on a cross-tree jump or multi-level forward push.
- Those synthetic entries never went through `_setAndroidFragmentTransitions`, so `goBack()`-ing onto one and then navigating forward again left the frame's transition bookkeeping desynced - the incoming `navigate()` never fires `navigatedTo`, permanently stuck `reconciling`, silently freezing every future route change app-wide until a full restart. Confirmed live in a downstream consumer app across two releases (5.2.0 and, generalized, 5.3.0), and reproduced in this repo's own CI (see the failing run this branch's history was built on top of investigating).
- An earlier attempt gave seeded entries a matching `frameId` (NativeScript's Android transition bookkeeping keys off it) - fixed the specific repro that motivated it, but the same freeze still reproduced on a forward navigate after landing on a seeded entry.
- Fixed by removing the synthetic-splice mechanism entirely: every skipped page now gets a real, queued `navigate()` call too (unanimated except the true destination), so every backstack entry gets the same paired transition-listener setup as any other. Trade-off: each skipped page still runs its own real (unanimated) fragment transaction/layout pass rather than zero native work - documented plainly in code/README rather than claiming an unmeasured perf win.

## Test plan
- [x] `pnpm exec eslint` / `pnpm exec glint` clean on the touched files
- [x] `pnpm build` succeeds
- [x] Extended `frame-element-test.ts` and `list-view-stack-test.ts` with the exact previously-hanging sequence (land on a skipped page via `goBack()`, then navigate forward again)
- [x] Real CI run on an Android emulator: `23 of 23 SUCCESS`, release-boot check passes (https://github.com/ember-native/ember-native/actions/runs/34553442982)

🤖 Generated with [Claude Code](https://claude.com/claude-code)